### PR TITLE
multiple dynamic library support

### DIFF
--- a/compiler/aux-file-serializer.stanza
+++ b/compiler/aux-file-serializer.stanza
@@ -79,7 +79,7 @@ defserializer AuxFileSerializer () :
   defunion projstmt (ProjStmt) :
     DefinedInStmt: (package:symbol, filename:string)
     PackagesDefinedInStmt: (packages:opt(symbol), filename:string)
-    RequiresStmt: (package:symbol, dylib:maybe(string), ccfiles:tuple(string), ccflags:tuple(string-or-tuple), foreign-packages:tuple(foreign-package))
+    RequiresStmt: (package:symbol, dylibs:tuple(string), ccfiles:tuple(string), ccflags:tuple(string-or-tuple), foreign-packages:tuple(foreign-package))
     ImportWhenStmt: (package:symbol, dependencies:tuple(symbol))
     CompileStmt: (file?:bool, name:string-or-tuple, dependencies:tuple(string), foreign-packages:tuple(foreign-package), commands:tuple(string))
     ForeignPackageParamsStmt: (package-manager:symbol, projdir:string, entries:tuple(keyvalue(symbol,projitem)))

--- a/compiler/loaded-dynamic-libraries.stanza
+++ b/compiler/loaded-dynamic-libraries.stanza
@@ -62,7 +62,7 @@ public deftype LoadedDynamicLibraries
 public defmulti set-library-folders (libs:LoadedDynamicLibraries, folders:Tuple<String>) -> False
 
 ;Load the given dynamic library. Throws exception if unsuccessful.
-public defmulti load-library (libs:LoadedDynamicLibraries, package:Symbol, name:String) -> False
+public defmulti load-libraries (libs:LoadedDynamicLibraries, package:Symbol, names:Tuple<String>) -> False
 
 ;Load the given symbols. Throws exception if unsuccessful.
 public defmulti load-symbols (libs:LoadedDynamicLibraries, symbols:Tuple<ExternSymbol>) -> False
@@ -77,7 +77,7 @@ public defmulti extern-address (libs:LoadedDynamicLibraries, id:Int) -> Long
 ;- library: The name of the library. If false, then
 ;  load from static extern table.
 public defstruct ExternSymbol <: Hashable & Equalable :
-  library: String|False
+  libraries: Tuple<String>
   symbol: Symbol
 with:
   hashable => true
@@ -90,7 +90,7 @@ with:
 public defn LoadedDynamicLibraries () :
 
   ;Table holding the libraries that each package requires.
-  val package-library-table = HashTable<Symbol,String>()
+  val package-libraries-table = HashTable<Symbol,Tuple<String>>()
 
   ;Table holding all the loaded libraries.
   val libraries = HashTable<String,DynamicLibrary>()
@@ -118,34 +118,38 @@ public defn LoadedDynamicLibraries () :
     defmethod set-library-folders (this, fs:Tuple<String>) :
       search-folders = fs
 
-    defmethod load-library (this, package:Symbol, name:String) :
-      package-library-table[package] = name
-      if not key?(libraries, name) :
-        val lib =
-          try : dynamic-library-open(search-folders, name)
-          catch (e) : throw(LoadLibraryError(package, name, search-folders))
-        libraries[name] = lib
+    defmethod load-libraries (this, package:Symbol, names:Tuple<String>) :
+      package-libraries-table[package] = names
+      for name in names do :
+        if not key?(libraries, name) :
+          val lib =
+            try : dynamic-library-open(search-folders, name)
+            catch (e) : throw(LoadLibraryError(package, name, search-folders))
+          libraries[name] = lib
 
     defmethod load-symbols (this, symbols:Tuple<ExternSymbol>) :
       val missing = Vector<ExternSymbol>()
       for sym in symbols do :
         if not key?(extern-symbol-table, sym) :
-          match(library(sym)) :
-            (lib:String) :
-              try :
-                val dysym = dynamic-library-symbol(libraries[lib], to-string(symbol(sym)))
-                add-symbol(sym, properties(dysym))
-              catch (e) :
-                add(missing, sym)
-            (f:False) :
-              match(get?(static-extern-table, symbol(sym))) :
-                (index:Int) : add-symbol(sym, static-symbol-properties(index))
-                (f:False) : add(missing, sym)
+          if empty?(/libraries(sym)) :
+            match(get?(static-extern-table, symbol(sym))) :
+              (index:Int) : add-symbol(sym, static-symbol-properties(index))
+              (f:False) : add(missing, sym)
+          else :
+            label<False> break :
+              for lib in /libraries(sym) do :
+                try :
+                  val dysym = dynamic-library-symbol(libraries[lib], to-string(symbol(sym)))
+                  add-symbol(sym, properties(dysym))
+                  break(false)
+                catch (e) :
+                  false
+              add(missing, sym)
       if not empty?(missing) :
         throw(LoadSymbolsError(to-tuple(missing)))
 
     defmethod id (this, package:Symbol, sym:Symbol) :
-      val extsym = ExternSymbol(get?(package-library-table,package), sym)
+      val extsym = ExternSymbol(get?(package-libraries-table,package,[]), sym)
       if not key?(extern-symbol-table,extsym) :
         fatal("Extern symbol %_ not yet loaded." % [extsym])
       extern-symbol-table[extsym]
@@ -232,22 +236,22 @@ defmethod print (o:OutputStream, e:LoadSymbolsError) :
   val messages = Vector<?>()
 
   ;Group symbols by the library they're from.
-  val groups = group-by(library, symbols(e))
+  val groups = group-by(libraries, symbols(e))
 
   ;Helper for collecting names of symbols.
   defn symbol-names (ss:Seqable<ExternSymbol>) :
     Indented("%n" % [seq(symbol, ss)])
 
   ;Generate messages for all symbols from libraries.
-  val string-groups = filter({key(_) is String}, groups)
+  val string-groups = filter({key(_) is Tuple<String>}, groups)
   for entry in string-groups do :
-    add(messages, "The following extern symbols could not be loaded from dynamic library %~:\n%_" % [
+    add(messages, "The following extern symbols could not be loaded from dynamic libraries %~:\n%_" % [
       key(entry), symbol-names(value(entry))])
 
   ;Generate message for all symbols expecting to be statically included.
-  if key?(groups, false) :
+  if key?(groups, []) :
     val msg = "The following extern symbols were expected to be statically-included in the current compiler, \
-               but were not found:\n%_" % [symbol-names(groups[false])]
+               but were not found:\n%_" % [symbol-names(groups[[]])]
     add(messages, msg)
 
   ;Print the final message.

--- a/compiler/proj-field-types.stanza
+++ b/compiler/proj-field-types.stanza
@@ -102,21 +102,21 @@ defmethod convert (s:DylibDirectoryStmtS0, extractor:Extractor) :
   DylibDirectoryStmt(dirs)
 
 defmethod map-fields (s:RequiresStmtS0, mapper:Mapper) :
-  val dylib = map-field(mapper, dylib(s), SINGLE-NAME-OR-PATH)
+  val dylibs = map-field(mapper, dylibs(s), MULTIPLE-NAMES-OR-PATHS)
   val ccfiles = map-field(mapper, ccfiles(s), MULTIPLE-PATHS)
   val ccflags = map-field(mapper, ccflags(s), MULTIPLE-FLAGS)
   val fps = for fp in foreign-packages(s) map :
     val files = map-field(mapper, files(fp), MULTIPLE-STRINGS)
     ForeignPackageFilesS0(package-manager(fp), files)
-  RequiresStmtS0(info(s), package(s), dylib, ccfiles, ccflags, fps)
+  RequiresStmtS0(info(s), package(s), dylibs, ccfiles, ccflags, fps)
 defmethod convert (s:RequiresStmtS0, extractor:Extractor) :
-  val dylib = extract(extractor, dylib(s), SINGLE-NAME-OR-PATH)
+  val dylibs = extract(extractor, dylibs(s), MULTIPLE-NAMES-OR-PATHS)
   val ccfiles = extract-tuple(extractor, ccfiles(s), MULTIPLE-PATHS)
   val ccflags = extract-tuple(extractor, ccflags(s), MULTIPLE-FLAGS)
   val fps = for fp in foreign-packages(s) map :
     val files = extract-tuple(extractor, files(fp), MULTIPLE-STRINGS)
     ForeignPackageFiles(package-manager(fp), files)
-  RequiresStmt(package(s), dylib, ccfiles, ccflags, fps)
+  RequiresStmt(package(s), to-tuple(dylibs), ccfiles, ccflags, fps)
 
 defmethod map-fields (s:ImportWhenStmtS0, mapper:Mapper) :
   ImportWhenStmtS0(

--- a/compiler/proj-ir.stanza
+++ b/compiler/proj-ir.stanza
@@ -38,7 +38,7 @@ with:
 
 public defstruct RequiresStmt <: ProjStmt & Equalable :
   package: Symbol
-  dylib: Maybe<String>
+  dylibs: Tuple<String>
   ccfiles: Tuple<String>
   ccflags: Tuple<String|Tuple<String>>
   foreign-packages: Tuple<ForeignPackageFiles>
@@ -138,9 +138,9 @@ defmethod print (o:OutputStream, f:ProjFile) :
   print(o, "ProjFile%_" % [colon-field-list(stmts(f))])
 
 defmethod print (o:OutputStream, s:RequiresStmt) :
-  val dylib-str = written(value!(dylib(s))) when not empty?(dylib(s))
+  val dylib-strs = seq(written, dylibs(s)) when not empty?(dylibs(s))
   val items = [
-    falseable-field("dynamic-library", dylib-str)
+    falseable-field("dynamic-libraries", dylib-strs)
     named-emptyable-list-fields("ccfiles", seq(written,ccfiles(s)))
     named-emptyable-list-fields("ccflags", seq(written,ccflags(s)))
     inline-fields(foreign-packages(s))]

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -85,7 +85,7 @@ public defmulti dynamic-libraries (l:ProjManager, packages:Tuple<Symbol>) -> Req
 
 ;Represents the required libraries and folders for a set of Stanza packages.
 public defstruct RequiredLibraries :
-  packages: Tuple<KeyValue<Symbol,String>>
+  packages: Tuple<KeyValue<Symbol,Tuple<String>>>
   folders: Tuple<String>
   
 ;============================================================
@@ -129,10 +129,10 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
   ;Build dynamic libraries table.
   ;Each entry, PKG => LIB, means that the given package is stated to
   ;require loading the given dynamic library.
-  val dynamic-library-table = to-hashtable<Symbol,String> $
+  val dynamic-library-table = to-hashtable<Symbol,Tuple<String>> $
     for req in filter-by<RequiresStmt>(stmts(proj)) seq? :
-      if empty?(dylib(req)) : None()
-      else : One(package(req) => value!(dylib(req)))
+      if empty?(dylibs(req)) : None()
+      else : One(package(req) => dylibs(req))
 
   ;Find the source file that contains the package.
   defn source-file? (name:Symbol) -> String|False :
@@ -226,7 +226,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
       val package-libs = to-tuple $
         for package in packages seq? :
           match(get?(dynamic-library-table, package)) :
-            (lib:String) : One(package => lib)
+            (libs:Tuple<String>) : One(package => libs)
             (f:False) : None()
       ;Return bundled result
       RequiredLibraries(package-libs, folders)

--- a/compiler/proj-stage0.stanza
+++ b/compiler/proj-stage0.stanza
@@ -41,7 +41,7 @@ with: (printer => true)
 public defstruct RequiresStmtS0 <: ProjStmt :
   info: FileInfo|False with: (as-method => true)
   package: Symbol
-  dylib: Maybe<ProjValue>
+  dylibs: Maybe<ProjValue>
   ccfiles: Maybe<ProjValue>
   ccflags: Maybe<ProjValue>
   foreign-packages: Tuple<ForeignPackageFilesS0>
@@ -289,7 +289,7 @@ public defn map<?T> (f:ProjItem -> ProjItem, x:?T&ProjItem) -> T :
     (x:DefinedInStmtS0) : DefinedInStmtS0(info(x), package(x), h(filename(x)))
     (x:PackagesDefinedInStmtS0) : PackagesDefinedInStmtS0(info(x), packages(x), h(filename(x)))
     (x:DylibDirectoryStmtS0) : DylibDirectoryStmtS0(info(x), h(directories(x)))
-    (x:RequiresStmtS0) : RequiresStmtS0(info(x), package(x), h(dylib(x)), h(ccfiles(x)), h(ccflags(x)), h(foreign-packages(x)))
+    (x:RequiresStmtS0) : RequiresStmtS0(info(x), package(x), h(dylibs(x)), h(ccfiles(x)), h(ccflags(x)), h(foreign-packages(x)))
     (x:ImportWhenStmtS0) : ImportWhenStmtS0(info(x), package(x), h(dependencies(x)))
     (x:CompileStmtS0) : CompileStmtS0(info(x), file?(x), h(name(x)),
                                       h(dependencies(x)), h(foreign-packages(x)), h(commands(x)))

--- a/compiler/proj-value-types.stanza
+++ b/compiler/proj-value-types.stanza
@@ -89,6 +89,7 @@ public val MULTIPLE-PATHS = MultipleType(FilepathType)
 public val SINGLE-FLAG = FlagType
 public val MULTIPLE-FLAGS = MultipleType(FlagType)
 public val SINGLE-NAME-OR-PATH = NameOrPathType
+public val MULTIPLE-NAMES-OR-PATHS = MultipleType(NameOrPathType)
 public val SINGLE-SYMBOL = SymbolType
 public val MULTIPLE-SYMBOLS = MultipleType(SymbolType)
 public val MULTIPLE-STANZA-INPUTS = MultipleType(StanzaInputType)

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -549,17 +549,17 @@ public defn REPL (macro-plugins:Tuple<String>) :
 ;============================================================
 
 ;Retrieve all the extern symbols defined in the given packages.
-defn extern-symbols (libraries:Tuple<KeyValue<Symbol,String>>,
+defn extern-symbols (libraries:Tuple<KeyValue<Symbol,Tuple<String>>>,
                      vmps:Tuple<VMPackage>) -> Tuple<ExternSymbol> :
   ;Create table for looking up library for a given package.
-  val libtable = to-hashtable<Symbol,String>(libraries)
+  val libtable = to-hashtable<Symbol,Tuple<String>>(libraries)
 
   ;Create ExternSymbol.
   to-tuple $ to-hashset<ExternSymbol> $
     for package in vmps seq-cat :
-      val lib = get?(libtable, name(package))
+      val libs = get?(libtable, name(package), [])
       for e in externs(package) seq :
-        ExternSymbol(lib, name(e))
+        ExternSymbol(libs, name(e))
 
 ;Load the libraries and symbols for the externs in the given
 ;dynamic libraries.
@@ -572,8 +572,8 @@ defn load-dynamic-libraries (dylibs:LoadedDynamicLibraries,
   ;Load the necessary libraries.
   set-library-folders(dylibs, folders(libs))
   for entry in packages(libs) do :
-    val libname = value(entry)
-    load-library(dylibs, key(entry), libname)
+    val libnames = value(entry)
+    load-libraries(dylibs, key(entry), libnames)
 
   ;Load the symbols from the libraries.
   load-symbols(dylibs, extern-symbols(packages(libs), vmps))


### PR DESCRIPTION
generalize dynamic-library project file command to allow multiple libraries per package. change syntax, data structures, and lookup mechanisms to support it.