### PR TITLE
calc-stanza-version-bump.sh: limit version string to one line

### DIFF
--- a/ci/calc-stanza-version-bump.sh
+++ b/ci/calc-stanza-version-bump.sh
@@ -27,7 +27,7 @@ TOP="${PWD}"
 >&2 echo "         PARAMSVER:" "${PARAMSVER:=$(git -C "${REPODIR}" log -1 -p -m  \
                                                 | filterdiff -p1 -i compiler/params.stanza \
                                                 | sed -E -n "s/^\+public val STANZA-VERSION = \[(.*)\].*/\1/p" \
-                                                | tr -s ', ' .
+                                                | head -1 | tr -s ', ' .
                                               )}"
 
 if [[ "${PARAMSVER}" != "" ]] ; then


### PR DESCRIPTION
Some merge commits may list the compiler/params.stanza file twice.  This fix makes sure we only use one.