### PR TITLE
Command-line option '-debug' for stanza builds

### DIFF
--- a/compiler/aux-file-serializer.stanza
+++ b/compiler/aux-file-serializer.stanza
@@ -62,7 +62,7 @@ defserializer AuxFileSerializer () :
   defunion build-record-settings (BuildRecordSettings) :
     BuildRecordSettings: (inputs:tuple(string-or-symbol), vm-packages:tuple(string-or-symbol),
                           platform:opt(symbol), assembly:opt(string), output:opt(string), external-dependencies:opt(string),
-                          pkg-dir:opt(string), optimize?:bool, ccfiles:tuple(string), ccflags:tuple(string-or-tuple), flags:tuple(symbol))
+                          pkg-dir:opt(string), optimize?:bool, debug?:bool, ccfiles:tuple(string), ccflags:tuple(string-or-tuple), flags:tuple(symbol))
 
   defunion pkgstamp (PackageStamp) :
     PackageStamp: (location:pkglocation, source-hashstamp:opt(bytearray), pkg-hashstamp:opt(bytearray))

--- a/compiler/aux-file-utils.stanza
+++ b/compiler/aux-file-utils.stanza
@@ -16,6 +16,7 @@ public defn BuildRecordSettings (settings:BuildSettings) -> BuildRecordSettings 
     external-dependencies(settings)  ;external-dependencies
     pkg-dir(settings)                ;pkg-dir
     optimize?(settings)              ;optimize?
+    debug?(settings)                 ;optimize?
     ccfiles(settings)                ;ccfiles
     ccflags(settings)                ;ccflags
     flags(settings))                 ;flags

--- a/compiler/aux-file.stanza
+++ b/compiler/aux-file.stanza
@@ -61,7 +61,7 @@ public defn AuxFile (path:String) -> AuxFile :
   ;Call read-records() to re-read the auxfile if
   ;we detect that it has changed on-disk.
   defn read-records-if-changed () -> False :
-    val changed? = 
+    val changed? =
       if file-exists?(path) :
         match(records-stamp:FileStamp) :
           not up-to-date?(records-stamp)
@@ -172,6 +172,7 @@ public defstruct BuildRecordSettings <: Hashable & Equalable :
   external-dependencies: String|False
   pkg-dir: String|False
   optimize?: True|False
+  debug?: True|False
   ccfiles: Tuple<String>
   ccflags: Tuple<String|Tuple<String>>
   flags: Tuple<Symbol>
@@ -221,7 +222,7 @@ defmethod print (o:OutputStream, f:AuxFile) :
 
 defmethod print (o:OutputStream, r:AuxRecords) :
   val version-str = string-join(stanza-version(r), ".")
-  val items = [    
+  val items = [
     simple-field("stanza-version", version-str)
     inline-fields(records(r))]
   print(o, "AuxRecords%_" % [colon-field-list(items)])
@@ -232,7 +233,7 @@ defmethod print (o:OutputStream, r:PkgRecord) :
     simple-field("source-stamp", source-stamp(r))
     named-list-fields("flags", flags(r))
     bool-flag-field("optimize", optimize?(r))]
-  print(o, "PkgRecord %~%_" % [package(r), colon-field-list(items)])  
+  print(o, "PkgRecord %~%_" % [package(r), colon-field-list(items)])
 
 defmethod print (o:OutputStream, r:ExternalFileRecord) :
   val file-str = match(filetype(r)) :
@@ -263,6 +264,7 @@ defmethod print (o:OutputStream, s:BuildRecordSettings) :
     falseable-field("external-dependencies", external-dependencies(s))
     falseable-field("pkg-dir", pkg-dir(s))
     simple-field("optimize?", optimize?(s))
+    simple-field("debug?", debug?(s))
     named-emptyable-list-fields("ccfiles", ccfiles(s))
     named-emptyable-list-fields("ccflags", ccflags(s))
     named-emptyable-list-fields("flags", flags(s))]

--- a/compiler/compiler-build-settings.stanza
+++ b/compiler/compiler-build-settings.stanza
@@ -7,7 +7,7 @@ defpackage stz/compiler-build-settings :
 ;============================================================
 
 ;Represents the full set of input options for starting
-;a Stanza compilation job. 
+;a Stanza compilation job.
 public defstruct BuildSettings :
   inputs: BuildInputs with: (updater => sub-inputs)
   vm-packages: Tuple<String|Symbol> with: (updater => sub-vm-packages)
@@ -17,6 +17,7 @@ public defstruct BuildSettings :
   external-dependencies: String|False
   pkg-dir: String|False
   optimize?: True|False
+  debug?: True|False
   ccfiles: Tuple<String>
   ccflags: Tuple<String|Tuple<String>>
   flags: Tuple<Symbol>
@@ -87,13 +88,13 @@ public defn build-inputs! (s:BuildSettings) -> Tuple<String|Symbol> :
 public defn build-target? (s:BuildSettings) -> Symbol|False :
   match(inputs(s)) :
     (t:BuildTarget) : target(t)
-    (p:BuildPackages) : original-target(p)  
+    (p:BuildPackages) : original-target(p)
 
 ;Returns true if an output executable is desired.
 ;This is the only condition that requires the build commands
 ;to be executed.
 public defn output-required? (s:BuildSettings) -> True|False :
-  output(s) is-not False  
+  output(s) is-not False
 
 ;Returns true if an output assembly file is desired,
 ;but the output is not. This condition is important because
@@ -115,7 +116,7 @@ public defn only-pkgs-required? (s:BuildSettings) -> True|False :
 ;============================================================
 
 ;This ensures that the BuildSettings was correctly computed
-;and ready to use as input for compilation. 
+;and ready to use as input for compilation.
 public defn ensure-ready-for-compilation! (s:BuildSettings) -> False :
   ;Requirements:
   ;1. Build inputs is BuildPackages, not BuildTarget.
@@ -139,4 +140,3 @@ public defn ensure-ready-for-compilation! (s:BuildSettings) -> False :
   if external-dependencies(s) is-not False :
     if assembly(s) is False and output(s) is False :
       fatal("External dependencies requires either assembly or output executable.")
-

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -24,11 +24,11 @@ Input:
   denv: DEnv
   packages: Seqable<EPackage|VMPackage|Pkg>
   input-order: Tuple<Symbol>
-  
+
 Output:
   packages: Tuple<EPackage|VMPackage|Pkg>
 
-Reorders the given input by their proper dependency order. 
+Reorders the given input by their proper dependency order.
 
 # Combine multiple EL packages into a single optimized VMPackage #
 
@@ -152,9 +152,10 @@ public defn compile (proj-manager:ProjManager,
                      pkg-dir:False|String,
                      backend:Backend,
                      optimize?:True|False,
+                     debug?:True|False,
                      verbose?:True|False,
                      macro-plugins:Tuple<String>,
-                     force-build-macros?:True|False) -> CompilationResult :  
+                     force-build-macros?:True|False) -> CompilationResult :
   defn driver () :
     val denv = DEnv()
     val macroexpander = StanzaMacroexpander(force-build-macros?, proj-manager, macro-plugins)
@@ -165,6 +166,7 @@ public defn compile (proj-manager:ProjManager,
       defmethod load-into-denv (this, ios:Tuple<PackageIO>) : load(denv, ios, [])
       defmethod conditional-dependencies (this, pkgs:Seqable<Symbol>) : conditional-imports(proj-manager, pkgs)
       defmethod supported-vm-packages (this) : supported-vm-packages
+      defmethod debug? (this) : debug?
       defmethod verbose? (this) : verbose?
       defmethod macroexpander (this) : macroexpander
 
@@ -173,7 +175,7 @@ public defn compile (proj-manager:ProjManager,
 
     ;Record filestamp of any output pkgs
     val output-pkgs = Vector<FileStamp>()
-    
+
     ;Save optimized packages if necessary
     if pkg-dir is String and optimize? :
       within save = save-pkgs(pkgstamp-table, output-pkgs) :
@@ -219,14 +221,14 @@ public defn compile (proj-manager:ProjManager,
                       pkgstamps(result),
                       to-tuple(output-pkgs))
 
-  defn save-pkgs (body:(Pkg -> False) -> ?,  
+  defn save-pkgs (body:(Pkg -> False) -> ?,
                   pkgstamp-table:HashTable<Symbol,PackageStamp>,
                   output-pkgs:Vector<FileStamp>) :
     match(pkg-dir:String) :
       val saved-pkgs = Vector<SavedPkg>()
       defn save-pkg (pkg:Pkg) :
         val filename = save-package(pkg-dir as String, pkg)
-        val stamp = pkgstamp-table[name(pkg)]      
+        val stamp = pkgstamp-table[name(pkg)]
         val filestamp = filestamp(filename)
         add(output-pkgs, filestamp)
         val full-source-path = resolve-path!(source-file(location(stamp)) as String)
@@ -261,12 +263,12 @@ public defn compile (proj-manager:ProjManager,
         match(npkg) :
           (npkg:NormVMPackage) :
             val ins = compile-normalized-vmpackage(filestream, npkg, stitcher, stubs, save-pkgs?)
-            save-pkg(StdPkg(pkg as VMPackage, ins as Tuple<Ins>, datas(npkg))) when save-pkgs?              
+            save-pkg(StdPkg(pkg as VMPackage, ins as Tuple<Ins>, datas(npkg))) when save-pkgs?
           (std-pkg:StdPkg) :
             compile-stdpkg(filestream, std-pkg, stitcher)
       emit-all-system-stubs(filestream, stitcher, stubs, includes-stz-vm?)
       emit-text-section-markers(filestream, stubs, `stanza_text_section_end)
-      
+
     ;Create filestream and compile to it.
     ensure-containing-directory-exists(filename)
     val filestream = FileOutputStream(filename)
@@ -288,7 +290,7 @@ public defn compile (proj-manager:ProjManager,
     if return-instructions? :
       val buffer = Vector<Ins>()
       val emitter = buffer-emitter(buffer, emitter(stitcher, name(npkg), file-emitter(filestream, stubs)))
-      emit-normalized-package(npkg, emitter, stubs)      
+      emit-normalized-package(npkg, emitter, stubs)
       to-tuple(buffer)
     else :
       val emitter = emitter(stitcher, name(npkg), file-emitter(filestream, stubs))
@@ -302,7 +304,7 @@ public defn compile (proj-manager:ProjManager,
       val buffer = Vector<Ins>()
       emit-normalized-package(npkg, buffer-emitter(buffer, stubs), stubs)
       save-pkg(StdPkg(vmpackage, to-tuple(buffer), datas(npkg)))
-    
+
   defn emit-normalized-package (npkg:NormVMPackage, emitter:CodeEmitter, stubs:AsmStubs) :
     ;Create the debug table so that we can add debug comments
     ;to each function.
@@ -329,7 +331,7 @@ public defn compile (proj-manager:ProjManager,
       vprintln("[Function %_ of %_] Allocating registers for function %_ (%_)" % [index + 1, num-funcs, id(f), fcomment])
       emit(emitter, fcomment)
       emit(emitter, LinkLabel(id(f)))
-      allocate-registers(id(f), func(f), emitter, backend, stubs, false)
+      allocate-registers(id(f), func(f), emitter, backend, stubs, debug?, false)
 
   defn emit-all-system-stubs (filestream:OutputStream, stitcher:Stitcher, stubs:AsmStubs, vm-stubs?:True|False) :
     val emitter = file-emitter(filestream, stubs)
@@ -359,10 +361,10 @@ public defn compile (proj-manager:ProjManager,
         add(buffer, i)
       defmethod unique-label (this) :
         unique-id(stubs)
-        
+
   ;Launch
   driver()
-  
+
 ;============================================================
 ;============= Collapsing a Normalized Package ==============
 ;============================================================
@@ -385,4 +387,3 @@ defn collapse (p:NormVMPackage|StdPkg) :
     defmethod debug-table (this) : debug-table(vmp)
     defmethod safepoint-table (this) : safepoint-table(vmp)
     defmethod debug-name-table (this): debug-name-table(vmp)
-

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -63,6 +63,8 @@ defn compute-build-settings (projenv:StandardProjEnv,
       remove-duplicates!(build-flags)
       ;Compute build optimization level
       val build-optimization = optimize?(settings) or optimize(s)
+      ;Compute build optimization level
+      val build-debug = debug?(settings)
       ;Compute assembly
       val build-asm = string-or?(original-asm(settings), value?(assembly(s)))
       ;Compute output
@@ -99,6 +101,7 @@ defn compute-build-settings (projenv:StandardProjEnv,
         build-ext-deps,
         build-pkg-dir,
         build-optimization,
+        build-debug,
         build-ccfiles,
         build-ccflags,
         to-tuple(build-flags),
@@ -233,8 +236,8 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       setup-system-flags(settings*)
       val proj-manager = ProjManager(proj, ProjParams(compiler-flags(), optimize?(settings*)), auxfile)
       val comp-result = compile(proj-manager, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
-                                backend(platform(settings*) as Symbol), optimize?(settings*), verbose?, macro-plugins(settings*),
-                                inputs(settings) is BuildTarget)
+                                backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,
+                                macro-plugins(settings*), inputs(settings) is BuildTarget)
       save(auxfile)
       within delete-temporary-file-on-finish(settings*) :
         link-output-file(projenv, settings*, comp-result, proj, auxfile)
@@ -266,7 +269,7 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
         body()
       finally :
         try: delete-temporary-file(system, temp-file?)
-        catch (e) : false      
+        catch (e) : false
     else :
       body()
 
@@ -370,4 +373,3 @@ defn non-files-to-symbols (ss:Seqable<String|Symbol>) :
     match(s) :
       (s:String) : s when has-extension?(s) else to-symbol(s)
       (s:Symbol) : s
-

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -41,11 +41,11 @@ public defstruct DefsDbInput :
   optimize?: True|False
   merge-db?: String|False
   macro-plugins: Tuple<String>
-with : 
+with :
   printer => true
 
-; Main entry point, given the input data and an output filename, 
-; compile to IL-IR, create the definitions database, and serialize it 
+; Main entry point, given the input data and an output filename,
+; compile to IL-IR, create the definitions database, and serialize it
 ; to the output file.
 public defn defs-db (input:DefsDbInput, filename:String) :
   ;First analyze the input.
@@ -60,7 +60,7 @@ public defn defs-db (input:DefsDbInput, filename:String) :
       try : read-definitions-database(file)
       catch (e) : false
     (f:False) :
-      false    
+      false
 
   ;If a previous database exists, then merge the
   ;previous database against the new database.
@@ -95,15 +95,16 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false,                                  ;external dependencies
     false,                                  ;pkg-dir
     optimize?(input),                       ;optimize?
+    false,                                  ;debug?
     [],                                     ;ccfiles
     [],                                     ;ccflags
     flags(input)                            ;flags
     macro-plugins(input)                    ;macro-plugin
     false)                                  ;link-type
-    
+
   ;Compute dependencies (compiles to IL-IR)
   dependencies(build-settings, true)
-  
+
 ;============================================================
 ;============= Building the Database ========================
 ;============================================================
@@ -121,7 +122,7 @@ protected-when(TESTING) defn gen-defs-db (deps:DependencyResult) -> DefinitionsD
     val stamp = package-stamp-table[name(pkg)]
     build-package-defs(pkg, stamp, namemap(deps))
 
-  val unresolved-symbols = to-tuple $ 
+  val unresolved-symbols = to-tuple $
     for e in filter-by<NoResolve>(errors(deps)) seq :
       UnresolvedSymbol(name(e), /info?(info(e)))
 
@@ -142,7 +143,7 @@ defn build-package-defs (pkg:Pkg, stamp:PackageStamp, nm:NameMap) -> PackageDefi
   val exports-with-infos = filter({info(_) is-not False}, exports(packageio))
 
   ;Convert each of the exports into the database Definition objects.
-  val definitions = to-tuple $     
+  val definitions = to-tuple $
     for e in exports-with-infos seq :
       Definition(name, info, kind, visibility, annotation?, documentation?) where :
         val name = name(id(rec(e)))
@@ -164,20 +165,20 @@ defn build-package-defs (pkg:Pkg, stamp:PackageStamp, nm:NameMap) -> PackageDefi
 ;------------------------------------------------------------
 ; Index a package from source code. First index the expressions, then convert to a `Definition`
 ; object that can be serialized.
-protected-when(TESTING) defn build-package-defs (ipackage:IPackage, 
-                                                 stamp:PackageStamp, 
+protected-when(TESTING) defn build-package-defs (ipackage:IPackage,
+                                                 stamp:PackageStamp,
                                                  nm:NameMap) -> PackageDefinitions :
   ;Convert the IImport expression into a PackageImport.
   defn to-package-import (iimport:IImport) -> PackageImport :
-    val prefixes = for iprefix in prefix(iimport) map : 
+    val prefixes = for iprefix in prefix(iimport) map :
       PackageImportPrefix(names(iprefix), prefix(iprefix))
     PackageImport(package(iimport), prefixes)
 
   ;Index the expressions in the package to assemble the definitions.
   val indexed-exps = index-expressions(exps(ipackage), nm)
   val definitions = to-tuple $
-    for indexed in indexed-exps seq :  
-      Definition(name, info, kind, visibility, annotation?, documentation?) where : 
+    for indexed in indexed-exps seq :
+      Definition(name, info, kind, visibility, annotation?, documentation?) where :
         val name = name(indexed)
         val info = info(indexed)
         val kind = kind(indexed)
@@ -193,7 +194,7 @@ protected-when(TESTING) defn build-package-defs (ipackage:IPackage,
                      map(to-package-import, imports(ipackage)),
                      definitions)
 
-; Depth first walk of the IL-IR to flatten into a sequence of `Indexed`, or 
+; Depth first walk of the IL-IR to flatten into a sequence of `Indexed`, or
 ; IExp nodes that have a meaningful name and FileInfo
 ;
 ; Input: The top level IExp nodes from IL-IR, and a NameMap to lookup associated
@@ -201,13 +202,13 @@ protected-when(TESTING) defn build-package-defs (ipackage:IPackage,
 ;
 ; Output: A sequence of indexed expressions.
 ;
-; Expected Behavior : 
+; Expected Behavior :
 ; - When encountering an `IVisibility` node, traverse its child using that node's visibility
 ; - When encountering an `IBegin`, traverse its children with the current visibility.
 ; - The initial visibility is `Private`
 ; - If an expression is not `Indexable`, it is skipped
 ; - If an `Indexable` does not have an `info`, it is skipped
-; - If an `Indexable`'s name cannot be found, it is skipped 
+; - If an `Indexable`'s name cannot be found, it is skipped
 protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> Seq<Indexed> :
   generate<Indexed> :
     ;Returns the documentation that should be used for the next expression
@@ -215,7 +216,7 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
     defn loop (e:IExp,
                current-visibility:Visibility,
                documentation?:False|String) -> String|False :
-      match(e) : 
+      match(e) :
         ; Case 0: We encounter a doc string. Attribute it with
         ;         the next expression.
         (d:IDoc) :
@@ -223,9 +224,9 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
 
         ; Case 1: We encounter a visibility node. Walk its
         ;         child with the new visibility.
-        (v:IVisibility) : 
+        (v:IVisibility) :
           loop(exp(v), visibility(v), documentation?)
-          
+
         ; Case 2: We encounter a `Begin` node. Walk its children
         ;         reusing the current visibility
         (b:IBegin) :
@@ -233,7 +234,7 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
 
         ; Case 3: We find an Indexable. Attempt to index it.
         (i:Indexable&IExp) :
-          ; Extract metadata from the IExp. 
+          ; Extract metadata from the IExp.
           val name = name?(i, nm)
           val info = info(i as IExp)
           val kind = kindof(i)
@@ -242,7 +243,7 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
 
           ; Case 4a.: Successfully found info and name, yield
           ; Case 4b.: (implicit) If name or info is not found, skip.
-          match(info:AbsoluteFileInfo, name:Symbol) : 
+          match(info:AbsoluteFileInfo, name:Symbol) :
             yield(Indexed(kind, current-visibility, name, /info(info), annotation?, documentation?))
 
           ; Return false to indicate that the documentation has been attributed.
@@ -264,7 +265,7 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
       else :
         val new-doc? = loop(head(es), current-visibility, documentation?)
         loop(tail(es), current-visibility, new-doc?)
-          
+
     ; launch!
     loop(exps, Private, false)
 
@@ -276,34 +277,34 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
 defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
   match(iexp) :
     (idefn:IDefn|IDefmethod|ILSDefn|ILSDefmethod) :
-      DefnAnnotation(targs, args, return-type?) where :  
+      DefnAnnotation(targs, args, return-type?) where :
         val return-type? = stringify?(a2(idefn), nm)
-        val targs = to-tuple $ 
-          for arg in targs(idefn) seq : 
+        val targs = to-tuple $
+          for arg in targs(idefn) seq :
             stringify?(arg, nm) as Symbol
-        val args = to-tuple $ 
-          for (arg in args(idefn), type in a1(idefn)) seq : 
+        val args = to-tuple $
+          for (arg in args(idefn), type in a1(idefn)) seq :
             val arg-name = stringify?(arg, nm)
             val type-name = stringify?(type, nm)
             FnArgAnnotation(arg-name, type-name)
     (iexp) :
       false
-    
+
 ;Create an annotation for a PackageIO Export expression.
-defn annotate? (export:Export, nm:NameMap) -> False|DefinitionAnnotation : 
+defn annotate? (export:Export, nm:NameMap) -> False|DefinitionAnnotation :
   match(rec(export)) :
-    (rec:FnRec|MultiRec) : 
-      DefnAnnotation(targs, args, return-type?) where : 
+    (rec:FnRec|MultiRec) :
+      DefnAnnotation(targs, args, return-type?) where :
         val fnid = id(rec) as FnId
         val return-type? = stringify?(a2(rec), nm)
-        val targs = to-tuple $ 
-          for n in 0 to (ntargs(fnid) + ncargs(fnid)) seq : 
-            if n < ntargs(fnid) : 
+        val targs = to-tuple $
+          for n in 0 to (ntargs(fnid) + ncargs(fnid)) seq :
+            if n < ntargs(fnid) :
               to-symbol("TV%_" % [n])
-            else : 
+            else :
               to-symbol("?TV%_" % [n])
-        val args = to-tuple $ 
-          for (arg-type in a1(id(rec) as FnId), n in 0 to false) seq : 
+        val args = to-tuple $
+          for (arg-type in a1(id(rec) as FnId), n in 0 to false) seq :
             FnArgAnnotation(to-symbol("_%_" % [n]), stringify?(arg-type, nm))
     (r:?) :
       false
@@ -317,9 +318,9 @@ val STANZA-RESERVED-WORDS = [
   "package" "import" "prefix-of" "prefix" "public" "protected" "private" "doc" "deftype" "defchild" "def"
   "defpackage" "defvar" "defn" "defn*" "defmulti" "defmethod" "defmethod*" "fn" "fn*"
   "multi" "begin" "let" "match" "branch" "new" "as" "as?" "set" "do"
-  "prim" "tuple" "quote" "none" "of" "and" "or" "->" 
+  "prim" "tuple" "quote" "none" "of" "and" "or" "->"
   "cap" "void" "new" "struct" "addr" "addr!" "deref"
-  "slot" "field" "do" "call-c" "prim" "sizeof" "tagof" 
+  "slot" "field" "do" "call-c" "prim" "sizeof" "tagof"
   "letexp" "and" "or" "set" "label" "labels" "block" "goto" "return"
   "let" "if" "match" "branch" "func" "def" "defvar" "deftype" "deffield"
   "extern" "extern-fn" "byte" "int" "long" "float" "double"
@@ -330,8 +331,8 @@ val STANZA-RESERVED-WORDS = [
 ;------------------------------------------------------------
 
 ; Report the "kind" of an IExp.
-public defn kindof (e:IExp) -> SrcDefinitionKind : 
-  match(e) : 
+public defn kindof (e:IExp) -> SrcDefinitionKind :
+  match(e) :
     (e:IDefmulti) : SrcDefMulti
     (e:IDefmethod|ILSDefmethod) : SrcDefMethod
     (e:IDefn|ILSDefn) : SrcDefFunction
@@ -340,8 +341,8 @@ public defn kindof (e:IExp) -> SrcDefinitionKind :
     (e) : SrcDefUnknown
 
 ; Returns the "kind" of an Rec.
-public defn kindof (r:Rec) -> SrcDefinitionKind : 
-  match(r) : 
+public defn kindof (r:Rec) -> SrcDefinitionKind :
+  match(r) :
     (v:ValRec|ExternRec) : SrcDefVariable
     (f:FnRec|ExternFnRec) : SrcDefFunction
     (m:MultiRec) : SrcDefMulti
@@ -352,10 +353,10 @@ public defn kindof (r:Rec) -> SrcDefinitionKind :
 ;------------------ Indexable Type --------------------------
 ;------------------------------------------------------------
 
-; An Indexable is an IExp that can be meaningfully indexed in the DefinitionsDatabase 
+; An Indexable is an IExp that can be meaningfully indexed in the DefinitionsDatabase
 ; structure. Currently supported are functions, multis, methods, types, and children
 ; in both Hi and Lo stanza.
-deftype Indexable :  
+deftype Indexable :
   VarN         <: Indexable
   IDef         <: Indexable
   IDefn        <: Indexable
@@ -373,27 +374,27 @@ deftype Indexable :
 ;------------------------------------------------------------
 
 ; The `Indexed` struct is a helper that contains extracted metadata from IL-IR.
-; before being associated with a package. 
+; before being associated with a package.
 ;
 ;- kind:       The kind of originating expression (see SrcDefinitionKind)
 ;- visibility: The visibility of the expression (public|private|protected)
 ;- name:       The extracted name of the indexed expression
 ;- info:       The associated file info of the expression.
-protected defstruct Indexed <: Equalable : 
+protected defstruct Indexed <: Equalable :
   kind:SrcDefinitionKind
   visibility:Visibility
   name:Symbol
   info:FileInfo
   annotation?:False|DefinitionAnnotation
   documentation?:False|String
-with : 
+with :
   printer => true
 
 ; Index entries are `Equalable` for testing.
 defmethod equal? (l:Indexed, r:Indexed) :
-  kind(l) == kind(r) and 
-  visibility(l) == visibility(r) and 
-  name(l) == name(r) and 
+  kind(l) == kind(r) and
+  visibility(l) == visibility(r) and
+  name(l) == name(r) and
   info(l) == info(r)
 
 ;============================================================
@@ -405,7 +406,7 @@ defn stringify? (a:FArg<DType>, nm:NameMap) :
 
 ; A helper multi that converts some IR that represents a named
 ; "thing" (type, identifier, etc) into human readable text.
-defmulti stringify? (i:DType|IExp, nm:NameMap) -> False|Symbol : 
+defmulti stringify? (i:DType|IExp, nm:NameMap) -> False|Symbol :
   false
 
 ; Stringify types from lostanza types in pkg/fpkg files
@@ -416,7 +417,7 @@ defmethod stringify? (dtype:DFloat, nm:NameMap)    : `float
 defmethod stringify? (dtype:DDouble, nm:NameMap)   : `double
 defmethod stringify? (dtype:DUnknown, nm:NameMap)  : `?
 
-defmethod stringify? (dptr:DPtrT, nm:NameMap) : 
+defmethod stringify? (dptr:DPtrT, nm:NameMap) :
   to-symbol $ "ptr<%_>" % [stringify?(type(dptr), nm)]
 
 defmethod stringify? (dfn:DFnT, nm:NameMap) :
@@ -431,40 +432,40 @@ defmethod stringify? (dfn:DFnT, nm:NameMap) :
         if rstr is Symbol :
           to-symbol("fn (%, ...) -> %_" % [cat(a,[rstr]), b])
 
-defmethod stringify? (dtype:DOf, nm:NameMap) : 
-  if empty?(targs(dtype)) : 
+defmethod stringify? (dtype:DOf, nm:NameMap) :
+  if empty?(targs(dtype)) :
     name(id(dtype))
-  else : 
-    to-symbol $ "%_<%,>" % [name(id(dtype)), seq(stringify?{_, nm}, targs(dtype))]     
-  
-defmethod stringify? (dtype:DTVar, nm:NameMap) : 
+  else :
+    to-symbol $ "%_<%,>" % [name(id(dtype)), seq(stringify?{_, nm}, targs(dtype))]
+
+defmethod stringify? (dtype:DTVar, nm:NameMap) :
   to-symbol $ "TV%_" % [index(dtype)]
 
-defmethod stringify? (dtype:DCap, nm:NameMap) : 
+defmethod stringify? (dtype:DCap, nm:NameMap) :
   to-symbol $ "?%_" % [tvar(dtype)]
 
-defmethod stringify? (dtype:DAnd, nm:NameMap) : 
+defmethod stringify? (dtype:DAnd, nm:NameMap) :
   to-symbol $ string-join(seq(stringify?{_, nm}, types(dtype)), "&")
 
-defmethod stringify? (dtype:DOr, nm:NameMap) : 
+defmethod stringify? (dtype:DOr, nm:NameMap) :
   to-symbol $ string-join(seq(stringify?{_, nm}, types(dtype)), "|")
 
-defmethod stringify? (dtype:DTop, nm:NameMap) : 
+defmethod stringify? (dtype:DTop, nm:NameMap) :
   `?
 
-defmethod stringify? (dtype:DBot, nm:NameMap) : 
+defmethod stringify? (dtype:DBot, nm:NameMap) :
   `Void
 
-defmethod stringify? (dtype:DTuple, nm:NameMap) : 
+defmethod stringify? (dtype:DTuple, nm:NameMap) :
   to-symbol $ "[%,]" % [seq(stringify?{_, nm}, types(dtype))]
 
-defmethod stringify? (dtype:DArrow, nm:NameMap) : 
+defmethod stringify? (dtype:DArrow, nm:NameMap) :
   to-symbol $ "(%,) -> %_" % [
-    seq(stringify?{_, nm}, a1(dtype)), 
+    seq(stringify?{_, nm}, a1(dtype)),
     stringify?(a2(dtype), nm)]
 
-defmethod stringify? (e:VarN, nm:NameMap) : 
-  if key?(nm, n(e)) : 
+defmethod stringify? (e:VarN, nm:NameMap) :
+  if key?(nm, n(e)) :
     name(nm[n(e)])
 
 defmethod stringify? (e:IOptional, nm:NameMap) :
@@ -479,13 +480,13 @@ defmethod stringify? (e:IOptionalKeyword, nm:NameMap) :
 defmethod stringify? (e:IRest, nm:NameMap) :
   stringify?(name(e), nm)
 
-defmethod stringify? (r:Raw, nm:NameMap) : 
+defmethod stringify? (r:Raw, nm:NameMap) :
   stringify?(class(r), nm)
 
-defmethod stringify? (iof:IOf, nm:NameMap) : 
+defmethod stringify? (iof:IOf, nm:NameMap) :
   to-symbol("%_<%,>" % [stringify?(class(iof), nm),  seq(stringify?{_, nm}, args(iof))])
 
-defmethod stringify? (ior:IOr, nm:NameMap) : 
+defmethod stringify? (ior:IOr, nm:NameMap) :
   val l = stringify?(a(ior), nm)
   val r = stringify?(b(ior), nm)
   match(l:Symbol, r:Symbol) :
@@ -498,12 +499,12 @@ defmethod stringify? (iand:IAnd, nm:NameMap) :
     to-symbol("%_&%_" % [l, r])
 
 defmethod stringify? (igrad:IGradual, nm:NameMap) :
-  `? 
+  `?
 
 defmethod stringify? (inone:INone, nm:NameMap) :
   false
 
-defmethod stringify? (iarrow:IArrow, nm:NameMap) : 
+defmethod stringify? (iarrow:IArrow, nm:NameMap) :
   val l = map(stringify?{_, nm}, a1(iarrow))
   val r = stringify?(a2(iarrow), nm)
   if all?({_ is Symbol}, l) and r is Symbol :
@@ -512,12 +513,12 @@ defmethod stringify? (iarrow:IArrow, nm:NameMap) :
 defmethod stringify? (ivoid:IVoid, nm:NameMap) :
   `Void
 
-defmethod stringify? (icap:ICap, nm:NameMap) : 
+defmethod stringify? (icap:ICap, nm:NameMap) :
   val type = stringify?(name(icap), nm)
   match(type:Symbol) :
     to-symbol("?%_" % [type])
 
-defmethod stringify? (ituple:ITuple, nm:NameMap) : 
+defmethod stringify? (ituple:ITuple, nm:NameMap) :
   to-symbol("[%,]" % [seq(stringify?{_, nm}, exps(ituple))])
 
 ; Lookup the name of an Indexable from the name map.
@@ -525,15 +526,15 @@ defn name? (i:Indexable&IExp, nm:NameMap) -> False|Symbol :
   val exp-name =
     match(i) :
       (e:VarN) : e
-      (e:IDef|ILSDef|ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) : 
+      (e:IDef|ILSDef|ILSDefType|IDef|IDefVar|ILSDefn|IDefn|IDefmulti|IDefChild) :
         name(e)
-      (e:IDefType) : 
+      (e:IDefType) :
         class(e)
-      (e:IDefmethod|ILSDefmethod) : 
+      (e:IDefmethod|ILSDefmethod) :
         val name = multi(e)
         match(name:Mix) :
           head(exps(name))
-        else : 
+        else :
           name
   stringify?(exp-name, nm)
 
@@ -549,8 +550,8 @@ defn merge (old-db:DefinitionsDatabase, new-db:DefinitionsDatabase) -> Definitio
   ;Convert a tuple of package definitions into a table.
   defn to-table (defs:Tuple<PackageDefinitions>) :
     to-hashtable<Symbol,PackageDefinitions> $
-      for def in defs seq : name(def) => def  
-  val old-package-table = to-table(packages(old-db))    
+      for def in defs seq : name(def) => def
+  val old-package-table = to-table(packages(old-db))
   val new-package-table = to-table(packages(new-db))
 
   ;Compute the set of packages that appear on either table.
@@ -580,7 +581,7 @@ defn merge (old-db:DefinitionsDatabase, new-db:DefinitionsDatabase) -> Definitio
 ;================= Small Utilities ==========================
 ;============================================================
 
-;Retrieve all existing files in project. 
+;Retrieve all existing files in project.
 defn all-package-files (proj-file:ProjFile) -> Tuple<String> :
   ;Collect all paths.
   val paths = HashSet<String>()
@@ -598,7 +599,7 @@ defn all-package-files (proj-file:ProjFile) -> Tuple<String> :
 
   ;Return all paths
   to-tuple(paths)
-  
+
 ;Retrieve all stanza files listed (directly or indirectly) within
 ;a directory.
 defn get-all-stanza-files (return:String -> ?, path:String) -> False :

--- a/compiler/front-end.stanza
+++ b/compiler/front-end.stanza
@@ -78,7 +78,7 @@ precompiled .pkg packages.
 Inconsistencies will be caused by out-of-date packages loaded from
 .pkg files. Inconsistencies are classified into either unrecoverable
 errors, or errors potentially recoverable by reloading the original
-source file corresponding to the .pkg file. 
+source file corresponding to the .pkg file.
 
 ;============================================================
 ;=======================================================<doc>
@@ -110,6 +110,9 @@ public defmulti conditional-dependencies (inputs:FrontEndInputs,
 
 public defmulti supported-vm-packages (inputs:FrontEndInputs) -> Tuple<String|Symbol> :
   []
+
+public defmulti debug? (inputs:FrontEndInputs) -> True|False :
+  false
 
 public defmulti verbose? (inputs:FrontEndInputs) -> True|False :
   false
@@ -152,7 +155,7 @@ defmethod print (o:OutputStream, r:DependencyResult) :
 defn lnprint-block (o:OutputStream, name:String, xs:Seqable) :
   print(o, "\n")
   print-block(o, name, xs)
-  
+
 defn print-block (o:OutputStream, name:String, xs:Seqable) :
   val xs-items = to-seq(xs)
   if empty?(xs-items) :
@@ -192,6 +195,7 @@ defmulti compile-to-el (f:FrontEnd) -> FrontEndResult
 defmulti dependencies (f:FrontEnd) -> DependencyResult
 
 defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
+  val debug? = debug?(sys)
   ;----------------------------------------------------------
   ;--------------------- State ------------------------------
   ;----------------------------------------------------------
@@ -210,7 +214,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
     val input-package-names = to-tuple $ seq(name, input-objs)
     if verbose?(sys) :
       println("Input packages: %," % [input-package-names])
-    load-package-table!(input-objs)      
+    load-package-table!(input-objs)
     ;Begin the resolver loop.
     let loop () :
       ;Loop again after resolving recovery files.
@@ -222,7 +226,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
           for source in files do :
             println("  package %~ from %~" % [package(source), filename(source)])
         load-package-table! $ read-inputs!(files)
-        loop()        
+        loop()
 
       val [resolved, recovery-files] = resolve-packages-with-recovery!(input-package-names)
       if not empty?(recovery-files) :
@@ -250,7 +254,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
       ;into the program.
       val included-packages = to-hashset<Symbol> $
         seq(name, package-table)
-      
+
       ;Load remaining vm support packages
       val remaining-packages = to-tuple $
         for p in vm-packages filter :
@@ -265,7 +269,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
         for p in package-table seq? :
           if included-packages[name(p)] : None()
           else : One(p)
-          
+
       ;Calculate bindings
       val bindings = extract-bindings(binding-packages)
       val binding-package-names = map(name, binding-packages)
@@ -309,7 +313,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
   defn source-file? (name:Symbol) :
     match(package-location(name)) :
       (l:PkgLocation) : source-file(l)
-      (f:False) : false     
+      (f:False) : false
 
   defn record-pkgstamp (l:PkgLocation) :
     defn hashstamp? (file:String|False) -> ByteArray|False :
@@ -317,7 +321,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
         sha256-hash-file(file) when file-exists?(file)
     val stamp = PackageStamp(l, hashstamp?(source-file(l)), hashstamp?(pkg-file(l)))
     package-stamps[package(l)] = stamp
-    
+
   ;----------------------------------------------------------
   ;------------------- Reading Inputs -----------------------
   ;----------------------------------------------------------
@@ -346,7 +350,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
           else :
             throw(InvalidExtensionError(filename)))
 
-    defn package-matching! (filename:String, package-name:Symbol) -> IPackage|Pkg :      
+    defn package-matching! (filename:String, package-name:Symbol) -> IPackage|Pkg :
       val pkg = for pkg in read-packages(filename) find :
         name(pkg) == package-name
       throw(MissingPackageInFile(filename, package-name)) when pkg is False
@@ -370,15 +374,15 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
           (input:PackageName) :
             val loc = package-location!(package(input))
             add(objects, package-matching!(filename(loc), package(loc)))
-            record-pkgstamp(loc)        
+            record-pkgstamp(loc)
           (input:StanzaFile) :
             val pkgs = read-packages(filename(input))
             do(record-pkgstamp{pkg-location(_, filename(input))}, pkgs)
-            add-all(objects, pkgs)          
+            add-all(objects, pkgs)
           (input:PackageInFile) :
             val pkg = package-matching!(filename(input), package(input))
             record-pkgstamp(pkg-location(pkg, filename(input)))
-            add(objects, pkg)          
+            add(objects, pkg)
           (input:IPackage) :
             add(objects, input)
       catch (e:FrontEndError|IOException|CheckError|CheckErrors|PkgException|LexerException) :
@@ -439,7 +443,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
       add(errors, /errors(renamed) as RenameErrors)
     objects = sub-ipackages(objects, packages(renamed))
     do(add{package-table, _}, objects)
-    
+
   defn load-package-table! (objects:Collection<IPackage|Pkg>) :
     val errors = Vector<Exception>()
     load-package-table(objects, errors)
@@ -516,12 +520,12 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
     ;Include as a resolver input, all the IPackages in the package table.
     defn minus (xs:Seqable<Symbol>, ys:Tuple<Symbol>) :
       for x in xs filter :
-        not contains?(ys, x)    
+        not contains?(ys, x)
     val package-names* = to-tuple(cat(existing-packages, package-names)) where :
       val existing-packages = seq(name, ipackages(package-table)) - package-names
     val resolver-inputs = to-tuple $
       filter-by<IPackage|PackageExports>(seq(to-resolver-input?, package-names*))
-    
+
     val resolved = resolve-il(resolver-inputs, resolver-environment(errorlist))
     match(errors(resolved)) :
       (es:ResolveErrors) : add-all(errorlist, errors(es))
@@ -535,7 +539,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
   defn resolve-packages-with-recovery! (package-names:Tuple<Symbol>) -> [ResolverResult, Tuple<PackageInFile>] :
     val errorlist = Vector<Exception>()
     val resolved = resolve-packages(package-names, errorlist)
-    val new-inputs = HashTable<Symbol,PackageInFile>()    
+    val new-inputs = HashTable<Symbol,PackageInFile>()
     for e in errorlist do :
       match(e:MissingType) :
         match(source-file?(src-package(e))) :
@@ -559,9 +563,9 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
       defmethod stz/type/exports (this, package:Symbol) :
         match(environment-package?(sys, package)) :
           (io:PackageIO) : package-exports(io)
-          (f:False) : package-exports-table[package]        
+          (f:False) : package-exports-table[package]
     val typed = type-program!(resolved, env)
-    to-el(typed, transient?(sys))
+    to-el(typed, transient?(sys), debug?)
 
   ;----------------------------------------------------------
   ;------------------- Order Packages -----------------------
@@ -578,7 +582,7 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
   ;Returns false is successful.
   ;Otherwise, returns a collection of PackageInFile to use to
   ;try on the next iteration.
-  
+
   defn load-into-denv! (pkgs:Seqable<EPackage|Pkg>) -> Tuple<PackageInFile>|False :
     val packageios = to-tuple $ seq(packageio, pkgs)
     val result = load-into-denv(sys, packageios)
@@ -678,8 +682,8 @@ backed up by a source file.
 
 deftype InputSource :
   IPackage <: InputSource
-  PkgLocation <: InputSource  
-  
+  PkgLocation <: InputSource
+
 defstruct StanzaFile <: InputSource :
   filename: String
 

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -24,7 +24,7 @@ defpackage stz/main :
   import core/dynamic-library
   import stz/compiler-build-settings
   import stz/dir-utils
-  
+
   ;Macro Packages
   import stz/ast-lang
   import stz/ast-lang2
@@ -107,7 +107,7 @@ defn print-version-command () :
       println(
         LineWrapStream(current-output-stream(), 65),
         version-message())
-  
+
   Command("version",
           ZeroArg, false,
           flags,
@@ -123,7 +123,7 @@ defn build-system (verbose?:True|False) :
       ;Ensure that the directory for creating these files exist.
       ensure-containing-directory-exists(asm)
       ensure-containing-directory-exists(output)
-      
+
       ;Collect arguments
       val args = Vector<String>()
       defn emit-arg (s:String) : add(args, s)
@@ -133,7 +133,7 @@ defn build-system (verbose?:True|False) :
       val cc-prog = switch(platform) :
         `os-x : "cc"
         `linux : "cc"
-        `windows : "gcc"      
+        `windows : "gcc"
       emit-arg(cc-prog)
 
       ;All files
@@ -156,10 +156,10 @@ defn build-system (verbose?:True|False) :
       ;First directly try calling the cc-prog driver.
       try :
         ;Call system
-        val return-code = call-system(to-tuple(args))        
+        val return-code = call-system(to-tuple(args))
         ;Return true if successful
         return-code == 0
-        
+
       ;If this particular type of error occurs, then
       ;double-check whether GCC is installed.
       catch (e:ProcessLaunchError) :
@@ -175,7 +175,7 @@ defn build-system (verbose?:True|False) :
         ;The Windows "cmd /c" command expects the input command
         ;to be input as separate arguments. (This is a quirk resulting
         ;from how call-system is implemented in core.) Therefore
-        ;we have to first tokenize the command. 
+        ;we have to first tokenize the command.
         val cmd-args = to-tuple $ cat(
                          ["cmd" "/c"],
                          tokenize-shell-command(command))
@@ -183,13 +183,13 @@ defn build-system (verbose?:True|False) :
       else :
         call-system("sh", ["sh" "-c" command])
       false
-      
+
     defmethod make-temporary-file (this) :
       val filename = to-string("temp%_.s" % [rand()])
       if verbose? :
         println("Create temporary file %~." % [filename])
       filename
-      
+
     defmethod delete-temporary-file (this, file:String) :
       if verbose? :
         println("Delete temporary file %~." % [file])
@@ -223,6 +223,8 @@ val COMMON-STANZA-FLAGS = [
     "Requests the compiler to output the .pkg files. The name of the folder to store the output .pkg files can be optionally provided.")
   Flag("optimize", ZeroFlag, OptionalFlag,
     "Requests the compiler to compile in optimized mode.")
+  Flag("debug", ZeroFlag, OptionalFlag,
+    "Requests the compiler to compile for debugging.")
   Flag("link", OneFlag, OptionalFlag,
     "Provide the type of linking to use.")
   Flag("ccfiles", ZeroOrMoreFlag, OptionalFlag,
@@ -232,7 +234,7 @@ val COMMON-STANZA-FLAGS = [
   Flag("flags", ZeroOrMoreFlag, OptionalFlag,
     "The set of compile-time flags to be set before compilation of the source code.")
   Flag("verbose", ZeroFlag, OptionalFlag,
-    "Controls whether the compiler should output verbose messages indicating status of compilation.")      
+    "Controls whether the compiler should output verbose messages indicating status of compilation.")
   Flag("supported-vm-packages", ZeroOrMoreFlag, OptionalFlag,
     "The list of Stanza packages with extern definitions that the Stanza REPL should support.")
   Flag("platform", OneFlag, OptionalFlag,
@@ -259,12 +261,16 @@ defn ensure-supported-link! (cmd-args:CommandArgs) :
   if flag?(cmd-args, "link") :
     ensure-supported-link-types(to-symbol(cmd-args["link"]))
 
+defn ccflags (cmd-args:CommandArgs) -> Tuple<String> :
+  val flags = to-tuple(tokenize-shell-command(cmd-args["ccflags"])) when flag?(cmd-args, "ccflags") else []
+  to-tuple(cat(flags, ["-shared"])) when flag?(cmd-args, "debug") else flags
+
 ;============================================================
 ;================== Compilation =============================
 ;============================================================
 defn compile-command () :
   ;Verify wellformed arguments.
-  defn verify-args (cmd-args:CommandArgs) :        
+  defn verify-args (cmd-args:CommandArgs) :
     defn ensure-output-flag! () :
       val has-output? = flag?(cmd-args, "s") or flag?(cmd-args, "o") or flag?(cmd-args, "pkg")
       if not has-output? :
@@ -291,11 +297,6 @@ defn compile-command () :
         to-symbol(cmd-args[name]) when flag?(cmd-args, name)
       val pkg-dir = if flag?(cmd-args, "pkg") :
         value?(cmd-args["pkg"], ".")
-      val ccflags =
-        if flag?(cmd-args, "ccflags") :
-          val flag1 = cmd-args["ccflags"]
-          to-tuple(tokenize-shell-command(flag1))
-        else : []      
       BuildSettings(
         BuildPackages(to-tuple(args(cmd-args))),
         get?(cmd-args, "supported-vm-packages", [])
@@ -305,8 +306,9 @@ defn compile-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         flag?(cmd-args, "optimize")
+        flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
-        ccflags
+        ccflags(cmd-args)
         map(to-symbol, get?(cmd-args, "flags", []))
         get?(cmd-args, "macros", [])
         symbol?("link"))
@@ -316,20 +318,20 @@ defn compile-command () :
       within run-with-verbose-flag(cmd-args) :
         compile(build-settings(), build-system(verbose-setting?()), verbose-setting?())
 
-  ;Command 
+  ;Command
   Command("compile",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names.",
-          common-stanza-flags(["o" "s" "pkg" "optimize" "ccfiles" "ccflags" "flags"
+          common-stanza-flags(["o" "s" "pkg" "optimize" "debug" "ccfiles" "ccflags" "flags"
                                "verbose" "supported-vm-packages" "platform" "external-dependencies" "macros" "link" "timing-log"]),
           compile-msg, false, verify-args, intercept-no-match-exceptions(compile-action))
- 
+
 
 ;============================================================
 ;==================== Build Command =========================
 ;============================================================
 defn build-command () :
   ;Verify wellformed arguments.
-  defn verify-args (cmd-args:CommandArgs) :        
+  defn verify-args (cmd-args:CommandArgs) :
     ensure-supported-link!(cmd-args)
 
   ;Main action for command
@@ -342,11 +344,6 @@ defn build-command () :
         value?(cmd-args["pkg"], ".")
       val target = if empty?(args(cmd-args)) : `main
                    else : to-symbol(arg(cmd-args,0))
-      val ccflags =
-        if flag?(cmd-args, "ccflags") :
-          val flag1 = cmd-args["ccflags"]
-          to-tuple(tokenize-shell-command(flag1))
-        else : []      
       BuildSettings(
         BuildTarget(target)
         []
@@ -356,8 +353,9 @@ defn build-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         flag?(cmd-args, "optimize")
+        flag?(cmd-args, "debug")
         []
-        ccflags
+        ccflags(cmd-args)
         map(to-symbol, get?(cmd-args, "flags", []))
         get?(cmd-args, "macros", []),
         symbol?("link"))
@@ -365,12 +363,12 @@ defn build-command () :
     ;Launch!
     within run-with-timing-log(cmd-args) :
       within run-with-verbose-flag(cmd-args) :
-        compile(build-settings(), build-system(verbose-setting?()), verbose-setting?())        
+        compile(build-settings(), build-system(verbose-setting?()), verbose-setting?())
 
   ;Command definition
   Command("build",
           ZeroOrOneArg, "the name of the build target. If not supplied, the default build target is 'main'.",
-          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "flags" "optimize" "verbose" "ccflags" "macros" "link" "timing-log"]),
+          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
           build-msg, false, verify-args, intercept-no-match-exceptions(build))
 
 ;============================================================
@@ -382,7 +380,7 @@ defn clean-command () :
   cache between previously compiled source files and their resulting \
   .pkg files."
   defn clean (cmd-args:CommandArgs) :
-    read-config-file()  
+    read-config-file()
     delete-aux-file()
 
   Command("clean",
@@ -395,7 +393,7 @@ defn clean-command () :
 ;============================================================
 defn extend-command () :
   ;Verify wellformed arguments.
-  defn verify-args (cmd-args:CommandArgs) :        
+  defn verify-args (cmd-args:CommandArgs) :
     val has-output? = flag?(cmd-args, "s") or flag?(cmd-args, "o")
     if not has-output? :
       throw(ArgParseError("The 'extend' command requires either a -s or -o flag."))
@@ -408,11 +406,6 @@ defn extend-command () :
       compile(build-settings(), build-system(verbose?), verbose?)
 
     defn build-settings () :
-      val ccflags =
-        if flag?(cmd-args, "ccflags") :
-          val flag1 = cmd-args["ccflags"]
-          to-tuple(tokenize-shell-command(flag1))
-        else : []  
       val new-args = to-tuple $
         cat(args(cmd-args), ["stz/driver"])
       BuildSettings(
@@ -424,15 +417,16 @@ defn extend-command () :
         get?(cmd-args, "external-dependencies", false)
         false
         flag?(cmd-args, "optimize")
+        false
         get?(cmd-args, "ccfiles", [])
-        ccflags
+        ccflags(cmd-args)
         map(to-symbol, get?(cmd-args, "flags", []))
         get?(cmd-args, "macros", [])
         false)
 
     ;Launch!
     run-with-timing-log(main, cmd-args)
-  
+
   ;Command definition
   Command("extend",
           ZeroOrMoreArg, "the .stanza/.proj input files or Stanza packages to use to extend the current compiler with.",
@@ -445,7 +439,7 @@ defn extend-command () :
 ;============================================================
 defn compile-test-command () :
   ;Verify wellformed arguments.
-  defn verify-args (cmd-args:CommandArgs) :        
+  defn verify-args (cmd-args:CommandArgs) :
     defn ensure-output-flag! () :
       val has-output? = flag?(cmd-args, "s") or flag?(cmd-args, "o") or flag?(cmd-args, "pkg")
       if not has-output? :
@@ -475,11 +469,6 @@ defn compile-test-command () :
         to-symbol(cmd-args[name]) when flag?(cmd-args, name)
       val pkg-dir = if flag?(cmd-args, "pkg") :
         value?(cmd-args["pkg"], ".")
-      val ccflags =
-        if flag?(cmd-args, "ccflags") :
-          val flag1 = cmd-args["ccflags"]
-          to-tuple(tokenize-shell-command(flag1))
-        else : []      
       val new-args = to-tuple $ cat(
         args(cmd-args)
         ["stz/test-driver"])
@@ -495,8 +484,9 @@ defn compile-test-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         flag?(cmd-args, "optimize")
+        flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
-        ccflags
+        ccflags(cmd-args)
         new-flags
         get?(cmd-args, "macros", [])
         symbol?("link"))
@@ -507,7 +497,7 @@ defn compile-test-command () :
   ;Command definition
   Command("compile-test",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing tests.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "ccfiles" "ccflags" "flags" "optimize" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
                                "macros" "link" "timing-log"])
           compile-test-msg, false, verify-args, intercept-no-match-exceptions(compile-test))
 
@@ -516,7 +506,7 @@ defn compile-test-command () :
 ;============================================================
 defn compile-macros-command () :
   ;Verify wellformed arguments.
-  defn verify-args (cmd-args:CommandArgs) :        
+  defn verify-args (cmd-args:CommandArgs) :
     defn ensure-output-flag! () :
       val has-output? = flag?(cmd-args, "s") or flag?(cmd-args, "o") or flag?(cmd-args, "pkg")
       if not has-output? :
@@ -545,11 +535,6 @@ defn compile-macros-command () :
         to-symbol(cmd-args[name]) when flag?(cmd-args, name)
       val pkg-dir = if flag?(cmd-args, "pkg") :
         value?(cmd-args["pkg"], ".")
-      val ccflags =
-        if flag?(cmd-args, "ccflags") :
-          val flag1 = cmd-args["ccflags"]
-          to-tuple(tokenize-shell-command(flag1))
-        else : []      
       val new-args = to-tuple $ cat(
         args(cmd-args)
         ["stz/macro-plugin"])
@@ -562,8 +547,9 @@ defn compile-macros-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         flag?(cmd-args, "optimize")
+        false
         get?(cmd-args, "ccfiles", [])
-        ccflags
+        ccflags(cmd-args)
         get?(cmd-args, "flags", [])
         get?(cmd-args, "macros", []),
         false)
@@ -590,7 +576,7 @@ defn install-command () :
     Flag("path", OneFlag, OptionalFlag,
       "Provide the directory to generate the .stanza file in. By default, \
        the .stanza file is generated in the user's home directory.")]
-       
+
   ;Main action for command
   val install-msg = "Installs the Stanza compiler to the current system."
   defn install (cmd-args:CommandArgs) :
@@ -603,7 +589,7 @@ defn install-command () :
           Windows : `windows
           Linux : `linux
           OS-X : `os-x
-    
+
     ;Get installation directory
     val install-dir = match(resolve-path(system-filepath(".", StanzaLicense))) :
       (path:String) :
@@ -628,8 +614,8 @@ defn install-command () :
         match(resolve-path(filepath)) :
           (fullpath:String) :
             val dir = to-string(enclosing-dir(fullpath))
-            println("Stanza installation finished. Created %_ file." % [fullpath])                  
-            println("Remember to add %_ to your STANZA_CONFIG environment variable." % [dir])                  
+            println("Stanza installation finished. Created %_ file." % [fullpath])
+            println("Remember to add %_ to your STANZA_CONFIG environment variable." % [dir])
           (fullpath:False) :
             throw $ Exception("Stanza installation failed. Could not create %_ file." % [filepath])
       else :
@@ -638,7 +624,7 @@ defn install-command () :
             val filepath = system-filepath(home, DotStanza)
             spit(filepath, config-file-contents())
           (home:False) :
-            throw $ Exception("Could not locate user's home directory.")               
+            throw $ Exception("Could not locate user's home directory.")
 
     ;Driver
     open-and-write-config-file()
@@ -731,7 +717,7 @@ defn repl-command () :
           else :
             default-terminal-style()
 
-        ;Launch REPL  
+        ;Launch REPL
         repl(args(cmd-args),
              terminal-style,
              get?(cmd-args, "macros", []))
@@ -780,7 +766,7 @@ defn run-command () :
   defn launch-run (cmd-args:CommandArgs) :
     ;Support timing logs
     within run-with-timing-log(cmd-args) :
-      within run-with-verbose-flag(cmd-args) :    
+      within run-with-verbose-flag(cmd-args) :
         ;Read configuration file
         within log-time(READ-CONFIG-FILE) :
           read-config-file()
@@ -837,7 +823,7 @@ defn run-test-command () :
   defn run-tests (cmd-args:CommandArgs) :
     ;Support timing log
     within run-with-timing-log(cmd-args) :
-    
+
       ;Read configuration file
       read-config-file()
 
@@ -859,7 +845,7 @@ defn run-test-command () :
       val new-args = to-tuple $ cat(
         args(cmd-args)
         ["stz/test-driver"])
-     
+
       ;Create new command-line arguments for test driver
       val driver-flags = Vector<String>()
       defn emit-flag (s:String) : add(driver-flags, s)
@@ -911,7 +897,7 @@ defn analyze-dependencies-command () :
     defn ensure-single-build-target! () :
       if flag?(cmd-args, "build-target") and num-args(cmd-args) != 1 :
         throw(ArgParseError("If the -build-target flag is given, then there needs to be exactly one argument \
-                             provided: the name of the build target."))        
+                             provided: the name of the build target."))
     ensure-supported-platform!(cmd-args)
     ensure-single-build-target!()
 
@@ -946,6 +932,7 @@ defn analyze-dependencies-command () :
         false
         pkg-dir
         flag?(cmd-args, "optimize")
+        false
         []
         []
         map(to-symbol, get?(cmd-args, "flags", []))
@@ -983,10 +970,10 @@ defn auto-doc-command () :
     defn ensure-single-build-target! () :
       if flag?(cmd-args, "build-target") and num-args(cmd-args) != 1 :
         throw(ArgParseError("If the -build-target flag is given, then there needs to be exactly one argument \
-                             provided: the name of the build target."))        
+                             provided: the name of the build target."))
     ensure-supported-platform!(cmd-args)
     ensure-single-build-target!()
-    
+
   ;Main action for command
   val auto-doc-msg = "Autogenerates documentation from Stanza source files."
   defn auto-doc-action (cmd-args:CommandArgs) :
@@ -1017,6 +1004,7 @@ defn auto-doc-command () :
         false
         pkg-dir
         flag?(cmd-args, "optimize")
+        false
         []
         []
         map(to-symbol, get?(cmd-args, "flags", []))
@@ -1031,7 +1019,7 @@ defn auto-doc-command () :
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names to generate documentation for."
           to-tuple $ cat(new-flags, common-stanza-flags(["pkg", "flags", "optimize", "macros", "timing-log"])),
           auto-doc-msg, false, verify-args, intercept-no-match-exceptions(auto-doc-action))
- 
+
 
 ;============================================================
 ;======================= DefsDB Command =====================
@@ -1051,13 +1039,13 @@ defn defs-db-command () :
     defn ensure-proj-file! (file:String) :
       if not suffix?(file, ".proj") :
         throw(ArgParseError("File %~ is not a valid file for building definitions database. \
-                             A project file (.proj) is expected." % [file]))                         
+                             A project file (.proj) is expected." % [file]))
     do(ensure-proj-file!, args(cmd-args))
-  
+
   ;Main action for command
   val defs-db-msg = "Generates the Stanza definitions database that is used \
   in conjunction with the Stanza language server."
-  
+
   defn defs-db-action (cmd-args:CommandArgs) :
     defn main () :
       read-config-file()
@@ -1081,7 +1069,7 @@ defn defs-db-command () :
           AtLeastOneArg, "the .proj files to use to generate definitions for.",
           to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "optimize", "macros", "timing-log"])),
           defs-db-msg, false, verify-args, intercept-no-match-exceptions(defs-db-action))
- 
+
 
 ;============================================================
 ;================== Check Docs Command ======================
@@ -1153,7 +1141,7 @@ add-stanza-command(analyze-dependencies-command())
 add-stanza-command(clean-command())
 add-stanza-command(check-docs-command())
 add-stanza-command(auto-doc-command())
-add-stanza-command(defs-db-command())    
+add-stanza-command(defs-db-command())
 
 ;============================================================
 ;================== Main Interface ==========================
@@ -1163,6 +1151,6 @@ public defn stanza-main (commands:Collection<Command>, default-command:String|Fa
   initialize-process-launcher()
   set-max-heap-size(STANZA-MAX-COMPILER-HEAP-SIZE)
   simple-command-line-cli(version-message(), to-tuple(commands), default-command, true)
-  
+
 public defn stanza-main () :
   stanza-main(stanza-commands(), "compile")

--- a/compiler/proj-ir.stanza
+++ b/compiler/proj-ir.stanza
@@ -113,7 +113,7 @@ defmethod print (o:OutputStream, v:ProjTable) :
   defn str (e:KeyValue<Symbol,?>) : "%~: %~" % [key(e), value(e)]
   if length(entries(v)) <= 1 :
     print(o, "{%,}" % [seq(str, entries(v))])
-  else :    
+  else :
     print(o, "{%_\n}" % [indented-field-list(seq(str, entries(v)))])
 
 ;============================================================

--- a/compiler/reg-alloc.stanza
+++ b/compiler/reg-alloc.stanza
@@ -213,6 +213,7 @@ public defn allocate-registers (context-id:Int,
                                 emitter:CodeEmitter,
                                 backend:Backend,
                                 stubs:AsmStubs,
+                                debug?:True|False,
                                 print?:True|False) -> False :
   take-ids(ins)
 
@@ -266,7 +267,7 @@ public defn allocate-registers (context-id:Int,
     println("==== Collapse Blocks ====")
     print-prog()
 
-  assemble(emitter, context-id, smap, stubs, print?)
+  assemble(emitter, context-id, smap, stubs, debug?, print?)
   clear-working-set()
 
 ;============================================================
@@ -1368,7 +1369,7 @@ defn add-annotations (blk:Block, b:Int) :
           else :
             val killed = to-list(filter({not live?(_)}, used-vars(e)))
             emit(attach-killed(e, to-list(killed)))
-            
+
           ;Cross call boundary
           if crosses-boundary?(e) :
             val live-set = IntSet()
@@ -1377,7 +1378,7 @@ defn add-annotations (blk:Block, b:Int) :
               requires-save[x] = true
               prefers-load[x] = false
             val live-vars = to-tuple(seq(Var,live-set))
-            emit(Op(RecordLiveOp(live-vars), List(), List(), List()))            
+            emit(Op(RecordLiveOp(live-vars), List(), List(), List()))
 
         ;Used
         fn (x:Var) :
@@ -2519,6 +2520,7 @@ defn assemble (emitter:CodeEmitter,
                context-id:Int,
                stackmap:StackMap,
                stubs:AsmStubs,
+               debug?:True|False,
                print?:True|False) :
   ;============================
   ;==== Assembly Utilities ====
@@ -2545,7 +2547,7 @@ defn assemble (emitter:CodeEmitter,
   ;====================
   ;==== VarContext ====
   ;====================
-  val safepoints-enabled? = contains?(EXPERIMENTAL-FEATURES, `safepoints)
+  val safepoints-enabled? = debug? and contains?(EXPERIMENTAL-FEATURES, `safepoints)
   val named-vars = Vector<asm-NamedVar>()
   val named-var-table = IntTable<Int>()
   for (v in 0 to false, name in VAR-NAMES) do :
@@ -2608,9 +2610,9 @@ defn assemble (emitter:CodeEmitter,
       (e:Call) :
         defn emit-info-label (label-id:Int, info:CallInfo) :
           val vmap = varmap(/named-vars(info)) when safepoints-enabled?
-          E $ asm-Label(label-id, 
+          E $ asm-Label(label-id,
                         trace-entry(info)
-                        vmap)            
+                        vmap)
 
         match(type(e)) :
           (t:ExtendStack) :

--- a/compiler/tl-to-el.stanza
+++ b/compiler/tl-to-el.stanza
@@ -34,7 +34,7 @@ val TL-TO-EL = TimerLabel("TL to EL")
 ;==================== Main Driver ===========================
 ;============================================================
 
-public defn to-el (p:TProg, transient-package?:True|False) -> Tuple<EPackage> :
+public defn to-el (p:TProg, transient-package?:True|False, debug?:True|False) -> Tuple<EPackage> :
   within log-time(TL-TO-EL) :
     ;Find all exports in program
     val export-table = ExportTable(p)
@@ -46,16 +46,17 @@ public defn to-el (p:TProg, transient-package?:True|False) -> Tuple<EPackage> :
       val struct-table = StructTable(packages(p), environment(p))
       to-tuple $ for package in packages(p) seq :
         within log-time(TL-TO-EL, suffix(name(package))) :
-          val compiled = compile(package, struct-table, namemap(p))
+          val compiled = compile(package, struct-table, namemap(p), debug?)
           val io = analyze-imports(compiled, export-table, transient-package?)
           sub-packageio(compiled, io)
 
-defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
+defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap, debug?:True|False) :
 
   ;Determine whether p is a non-system-package, so that safepoints
   ;can be emitted.
-  val not-system-package = not system-package?(p)
-  
+  val safepoints-enabled? = debug? and (not system-package?(p))
+  defn Compiler () : /Compiler(struct-table, namemap, safepoints-enabled?)
+
   val texps = Vector<ETExp>()
   defn emit (e:ETExp) : add(texps, e)
 
@@ -67,7 +68,6 @@ defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
         val parent = to-etype?(parent(c))
         val children = to-tuple(seq(n,children(c)))
         emit(EDefType(n(c), parent, children))
-        
       (c:TLDefType) :
         defn conv-field (f:Field) -> EDefField :
           EDefField(mutable?(f), name(f), to-etype(type(f)))
@@ -77,17 +77,16 @@ defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
           conv-field(unwrap-rest(lf))
         val parent = to-etype?(parent(c))
         emit(EDefStruct(n(c), parent, base, items))
-        
       (c:TDef) :
         val etype = to-etype(type(c) as Type)
         emit(EDefGlobal(n(c), etype, false, false))
-        val compiler = Compiler(struct-table, namemap, not-system-package)
+        val compiler = Compiler()
         val result = compile(compiler, value(c))
         /emit(compiler, ESafepoint(fresh-id(), info(c)))
         /emit(compiler, EStore(EVarLoc(n(c)), result, info(c)))
         emit(EInit(body(compiler), false))
       (c:TDefTuple) :
-        val compiler = Compiler(struct-table, namemap, not-system-package)
+        val compiler = Compiler()
         val tuple = compile(compiler, value(c))
         /emit(compiler, ECheckLength(tuple, length(ns(c)), info(c)))
         /emit(compiler, ESafepoint(fresh-id(), info(c)))
@@ -103,37 +102,37 @@ defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
         val v = value(c)
         emit(EDefGlobal(n(c), etype, true, false))
         match(v:TExp) :
-          val compiler = Compiler(struct-table, namemap, not-system-package)
+          val compiler = Compiler()
           val result = compile(compiler, v)
           /emit(compiler, ESafepoint(fresh-id(), info(c)))
           /emit(compiler, EStore(EVarLoc(n(c)), result, info(c)))
           emit(EInit(body(compiler), false))
       (c:TDefn) :
-        emit(EDefn(n(c), compile-function(c,struct-table,namemap, not-system-package), false))
+        val func = compile-function(c, struct-table, namemap, safepoints-enabled?)
+        emit(EDefn(n(c), func, false))
       (c:TDefmulti) :
         val targs* = to-tuple $
           for v in cat(targs(c), cargs(c)) seq :
             EFnTArg(v, debug-name?(namemap,v))
-        val args* = 
+        val args* =
           for arg in a1(c) map :
             EFnArg(fresh-id(), to-earg(arg), false)
         val ret* = to-etype(a2(c) as Type)
         emit(EDefmulti(n(c), targs*, args*, ret*, false, info(c)))
-        
       (c:TDefmethod) :
-        val func = compile-function(c,struct-table, namemap, not-system-package)
+        val func = compile-function(c,struct-table, namemap, safepoints-enabled?)
         val [multi, capargs] = multi-args(multi(c))
         val targs = to-tuple(cat(seq(ETVar,targs(c)), seq(to-etype,capargs)))
         emit(EDefmethod(n(c), multi, targs, func, false, false))
       (c:TInit) :
-        val compiler = Compiler(struct-table, namemap, not-system-package)
+        val compiler = Compiler()
         /emit(compiler, ESafepoint(fresh-id(), info(c)))
         compile(compiler, exp(c))
         emit(EInit(body(compiler), false))
       (c:TLDef) :
         val etype = to-etype(type(c))
         emit(EDefGlobal(n(c), etype, false, true))
-        val compiler = Compiler(struct-table, namemap, not-system-package)
+        val compiler = Compiler()
         val result = compile-upcast(compiler, value(c), type(c))
         /emit(compiler, ESafepoint(fresh-id(), info(c)))
         /emit(compiler, EStore(EVarLoc(n(c)), result, etype, info(c)))
@@ -143,28 +142,28 @@ defn compile (p:TPackage, struct-table:StructTable, namemap:NameMap) :
         val v = value(c)
         emit(EDefGlobal(n(c), etype, true, true))
         match(v:LSExp) :
-          val compiler = Compiler(struct-table, namemap, not-system-package)
+          val compiler = Compiler()
           val result = compile-upcast(compiler, v, type(c))
           /emit(compiler, ESafepoint(fresh-id(), info(c)))
           /emit(compiler, EStore(EVarLoc(n(c)), result, etype, info(c)))
           emit(EInit(body(compiler), true))
       (c:TLDefn) :
-        val func = compile-function(c, struct-table, namemap, not-system-package)
+        val func = compile-function(c, struct-table, namemap, safepoints-enabled?)
         emit(EDefn(n(c), func, true))
       (c:TLExternFn) :
-        val func = compile-function(c,struct-table,namemap,not-system-package)
+        val func = compile-function(c, struct-table, namemap, safepoints-enabled?)
         val ventry = namemap[n(c)]
         val exposed-lbl = lbl(c) when visibility(ventry) is-not Private
         emit(EExternFn(n(c), exposed-lbl, func))
       (c:TLDefmethod) :
-        val func = compile-function(c,struct-table,namemap,not-system-package)
+        val func = compile-function(c, struct-table, namemap, safepoints-enabled?)
         val [multi, capargs] = multi-args(multi(c))
         val targs = to-tuple(cat(seq(ETVar,targs(c)), seq(to-etype,capargs)))
         emit(EDefmethod(n(c), multi, targs, func, true, false))
       (c:TExtern) :
         emit(EExtern(n(c), lbl(c), to-etype(type(c))))
       (c:TLInit) :
-        val compiler = Compiler(struct-table, namemap, not-system-package)
+        val compiler = Compiler()
         compile(compiler, comm(c), false)
         emit(EInit(body(compiler), true))
 
@@ -272,15 +271,15 @@ defn Compiler (struct-table:StructTable,
   ;Use this as the id of the group for this particular compile session.
   ;It is assumed that each function is compiled using a new Compiler object.
   val safepoint-group = fresh-id()
-  
+
   ;Determine whether safepoints are enabled.
-  val safepoints-enabled? = contains?(stz/params/EXPERIMENTAL-FEATURES, `safepoints)
+  val safepoints-enabled? = emit-safepoints? and contains?(stz/params/EXPERIMENTAL-FEATURES, `safepoints)
 
   ;Add a new instruction to the instruction buffer.
   ;For safepoints specifically, add them only if the feature is turned-on.
   defn emit (l:EIns) :
     match(l:ESafepoint) :
-      add(ins, l) when emit-safepoints? and safepoints-enabled?
+      add(ins, l) when safepoints-enabled?
     else : add(ins, l)
 
   ;Emit new locals, types, functions, and objects to their
@@ -370,7 +369,7 @@ defn Compiler (struct-table:StructTable,
       (e:TSet) :
         emit(EStore(EVarLoc(n(ref(e))), compile(value(e)), info(e)))
         ELiteral(false)
-        
+
       (e:TDo) :
         ;Get types
         val a1 = arg-types(func(e))
@@ -386,7 +385,7 @@ defn Compiler (struct-table:StructTable,
         emit(ELocal(ret, e-a2, false, false))
         emit(ECall(EVarLoc(ret), func*, args*, CallGuarded(e-a1, e-a2), info(e)))
         EVar(ret,info(e))
-        
+
       (e:TPrim) :
         val ys = to-tuple(seq(compile, args(e)))
         val [op, type] = to-eop(op(e))
@@ -578,7 +577,7 @@ defn Compiler (struct-table:StructTable,
               defn call-ptr (f:EImm) :
                 emit(ETCall(f, args*, CallPtr(), info(e)))
           driver()
-                  
+
         (c:LSDef) :
           val type = type(c) as LSType
           emit(ELocal(n(c), to-etype(type), false, debug-name?(namemap,n(c))))
@@ -671,7 +670,7 @@ defn Compiler (struct-table:StructTable,
             to-local(ECall{_, add-targs(f, e-targs), ys, CallGuarded(e-a1, e-a2), info(e)}, e-a2)
           defn call-ptr (f:EImm) :
             to-local(ECall{_, add-targs(f, e-targs), ys, CallPtr(), info(e)}, e-a2)
-            
+
       (e:LSCallC) :
         ;Get types.
         val a1 = arg-types(func(e))
@@ -689,13 +688,13 @@ defn Compiler (struct-table:StructTable,
           (f:LSDeref) : y(compile-loc(f) as EDeptr)
           (f:LSExp) : compile(f)
         to-local(ECall{_, f*, ys, CallC(), info(e)}, e-a2)
-        
+
       (e:LSSizeof) :
         ESizeof(to-etype(targ(e)))
-        
+
       (e:LSTagof) :
         ETagof(n(e))
-        
+
       (e:LSCast) :
         val et = type(exp(e)) as LSType
         val xtype = to-etype(targ(e))
@@ -707,7 +706,7 @@ defn Compiler (struct-table:StructTable,
         val xtype = to-etype(targ(e))
         val result = compile(exp(e))
         to-local(EConv{_, result}, xtype)
-        
+
       (e:LSLiteral) :
         ELSLiteral(value(e))
       (e:LSAnd) :
@@ -963,7 +962,7 @@ defn Compiler (struct-table:StructTable,
     val target-type = match(desired-type, actual-type) :
       (dt:UnknownT, at:ByteT) : IntT()
       (dt:UnknownT, at:FloatT) : DoubleT()
-      (dt, at) : dt      
+      (dt, at) : dt
     ;Compile the expression.
     val result = compile(e)
     ;Upcast the expression if necessary.
@@ -971,7 +970,7 @@ defn Compiler (struct-table:StructTable,
       within v = to-local(to-etype(target-type)) :
         EConv(v, result)
     else :
-      result    
+      result
 
   ;Compile an expression, upcasting the result to a long.
   defn compile-long (e:LSExp) :
@@ -1017,7 +1016,7 @@ defn add-targs (f:EImm, targs:Tuple<EType>) -> EImm :
         EMix(new-funcs)
       (f:EInstFn) :
         val new-targs = to-tuple(cat(targs, capvars(f)))
-        sub-capvars(f, new-targs)        
+        sub-capvars(f, new-targs)
       (f) :
         fatal("Invalid function call with type arguments: %_" % [f])
 

--- a/core/sighandler.c
+++ b/core/sighandler.c
@@ -1,9 +1,3 @@
-//Platform-specific defines.
-#if defined(PLATFORM_LINUX)
-  //Needs to be defined to access REG_RIP.
-  #define _GNU_SOURCE
-#endif
-
 #include<ucontext.h>
 #include<signal.h>
 #include<stdint.h>

--- a/stanza.proj
+++ b/stanza.proj
@@ -50,6 +50,14 @@ package core/threaded-reader requires :
 package core/dynamic-library requires :
   ccfiles: "core/dynamic-library.c"
 
+package core/sighandler requires :
+  ccfiles: "core/sighandler.c"
+  ccflags:
+    on-platform:
+      os-x :
+        "-D_XOPEN_SOURCE"
+      else : ()
+
 package stz/asmjit requires :
   ccflags:
     on-platform :


### PR DESCRIPTION
- Introduce a command-line option `-debug`
- Make it acceptable for `compile`, `build` and `compile-test` commands
- When this option is specified, debug info is generated and shared object is linked to be loaded by the debugger
  Note: the debugger source code is not merged to `master` branch yet. No changes to the debugger are necessary for this commit.
- Safepoints are generated when `-debug` option is specified and safepoints are enabled in stanza config file. Otherwise no safepoints are generated.
- Debug name tables are not controlled by `-debug` option yet. They are in the works, stay tuned for the next commit.

The code is tested with multiple examples on Linux with standalone debugger utility only. It is supposed to work unchanged on MacOS. Windows OS is not yet supported.