### PR TITLE
Add logging to help debug slow builds.

### DIFF
--- a/compiler/aux-file.stanza
+++ b/compiler/aux-file.stanza
@@ -10,6 +10,7 @@ defpackage stz/aux-file :
   import stz/aux-file-serializer
   import stz/file-stamps
   import stz/printing-utils
+  import stz/verbose
 
 ;============================================================
 ;==================== Aux File Definition ===================
@@ -52,9 +53,11 @@ public defn AuxFile (path:String) -> AuxFile :
   ;Initialize records and records-stamp.
   defn read-records () :
     if file-exists?(path) :
+      vprintln("Read Stanza auxiliary file from %~." % [path])
       records = read-aux-records(path)
       records-stamp = filestamp(path)
     else :
+      vprintln("Stanza auxiliary file at %~ does not exist." % [path])
       records = AuxRecords(STANZA-VERSION, [])
       records-stamp = false
 

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -233,6 +233,9 @@ public defn compile (proj-manager:ProjManager,
         add(output-pkgs, filestamp)
         val full-source-path = resolve-path!(source-file(location(stamp)) as String)
         val sourcestamp = FileStamp(full-source-path, source-hashstamp(stamp) as ByteArray)
+        vprintln("Save output .pkg for package %~:" % [name(pkg)])
+        vprintln("  source-hashstamp: %_" % [sourcestamp])
+        vprintln("  pkg-hashstamp: %_" % [filestamp])
         add(saved-pkgs, SavedPkg(name(pkg), filestamp, sourcestamp))
       body(save-pkg)
       update-aux-file(proj-manager, saved-pkgs)
@@ -328,7 +331,7 @@ public defn compile (proj-manager:ProjManager,
     val num-funcs = length(funcs(vmpackage(npkg)))
     for (f in funcs(vmpackage(npkg)), index in 0 to false) do :
       val fcomment = function-comment(id(f))
-      vprintln("[Function %_ of %_] Allocating registers for function %_ (%_)" % [index + 1, num-funcs, id(f), fcomment])
+      vprintln(3, "[Function %_ of %_] Allocating registers for function %_ (%_)" % [index + 1, num-funcs, id(f), fcomment])
       emit(emitter, fcomment)
       emit(emitter, LinkLabel(id(f)))
       allocate-registers(id(f), func(f), emitter, backend, stubs, debug?, false)

--- a/compiler/el.stanza
+++ b/compiler/el.stanza
@@ -76,7 +76,7 @@ defn lower (epackage:EPackage, optimize?:True|False) -> EPackage :
 
     ;Run pass
     defn run-pass (pass-name:String, f:EPackage -> EPackage, suffix:String, update-tables?:True|False) :
-      vprintln("EL: Running pass %_" % [pass-name])
+      vprintln(2, "EL: Running pass %_" % [pass-name])
       within log-time(EL-TIMERS[pass-name], /suffix(name(epackage))) :
         cur-package = f(cur-package)
         update-tables() when update-tables?

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -71,7 +71,10 @@ defn run-with-timing-log<?T> (body:() -> ?T, cmd-args:CommandArgs) -> T :
 ;for verbosity level.
 defn run-with-verbose-flag<?T> (body:() -> ?T, cmd-args:CommandArgs) -> T :
   if flag?(cmd-args, "verbose") :
-    run-with-verbose-level(body, 1)
+    val setting:Maybe<String> = cmd-args["verbose"]
+    val level = if empty?(setting) : 1
+                else : to-int!(value!(setting))
+    run-with-verbose-level(body, level)
   else :
     body()
 
@@ -233,7 +236,7 @@ val COMMON-STANZA-FLAGS = [
     "The set of flags to pass to the linker to link the final generated assembly to produce the final executable.")
   Flag("flags", ZeroOrMoreFlag, OptionalFlag,
     "The set of compile-time flags to be set before compilation of the source code.")
-  Flag("verbose", ZeroFlag, OptionalFlag,
+  Flag("verbose", ZeroOrOneFlag, OptionalFlag,
     "Controls whether the compiler should output verbose messages indicating status of compilation.")
   Flag("supported-vm-packages", ZeroOrMoreFlag, OptionalFlag,
     "The list of Stanza packages with extern definitions that the Stanza REPL should support.")
@@ -260,6 +263,17 @@ defn ensure-supported-platform! (cmd-args:CommandArgs) :
 defn ensure-supported-link! (cmd-args:CommandArgs) :
   if flag?(cmd-args, "link") :
     ensure-supported-link-types(to-symbol(cmd-args["link"]))
+
+defn ensure-proper-verbose-level! (cmd-args:CommandArgs) :
+  if flag?(cmd-args, "verbose") :
+    val setting:Maybe<String> = cmd-args["verbose"]
+    if not empty?(setting) :
+      match(to-int(value!(setting))) :
+        (v:Int) : 
+          if v < 1 or v > 10 :
+            throw(ArgParseError("The '-verbose' flag requires an integer between 1 and 10."))
+        (f:False) :
+          throw(ArgParseError("The '-verbose' flag requires an integer between 1 and 10."))
 
 ;Extract the CC flags from the given command line arguments as a tuple.
 ;Handles tokenization.
@@ -295,6 +309,7 @@ defn compile-command () :
     ensure-supported-link!(cmd-args)
     ensure-output-flag!()
     ensure-output-for-dependencies!()
+    ensure-proper-verbose-level!(cmd-args)
 
   ;Main action for command
   val compile-msg = "Compile the given Stanza input files to either executable, \
@@ -341,6 +356,7 @@ defn build-command () :
   ;Verify wellformed arguments.
   defn verify-args (cmd-args:CommandArgs) :
     ensure-supported-link!(cmd-args)
+    ensure-proper-verbose-level!(cmd-args)
 
   ;Main action for command
   val build-msg = "Build one of the targets defined in the .proj file."
@@ -405,6 +421,7 @@ defn extend-command () :
     val has-output? = flag?(cmd-args, "s") or flag?(cmd-args, "o")
     if not has-output? :
       throw(ArgParseError("The 'extend' command requires either a -s or -o flag."))
+    ensure-proper-verbose-level!(cmd-args)
 
   ;Main action for command
   val extend-msg = "Extends the Stanza compiler with additional syntax packages and external bindings."
@@ -464,6 +481,7 @@ defn compile-test-command () :
     ensure-supported-link!(cmd-args)
     ensure-output-flag!()
     ensure-output-for-dependencies!()
+    ensure-proper-verbose-level!(cmd-args)
 
   ;Main action for command
   val compile-test-msg = "Compiles the given test files together with the Stanza testing framework to build a test executable."
@@ -530,6 +548,7 @@ defn compile-macros-command () :
     ensure-supported-platform!(cmd-args)
     ensure-output-flag!()
     ensure-output-for-dependencies!()
+    ensure-proper-verbose-level!(cmd-args)
 
   ;Main action for command
   val compile-macros-msg = "Compiles the given macros files together with the Stanza macro plugin framework to build a macro plugin."
@@ -769,6 +788,10 @@ defn run-command () :
     Flag("-", AllRemainingFlag, OptionalFlag,
       "If provided, the remaining arguments after this flag will be set as the command line arguments for the REPL session.")]
 
+  ;Verify that the passed options are good.
+  defn verify-args (cmd-args:CommandArgs) :
+    ensure-proper-verbose-level!(cmd-args)
+
   ;Main action for command
   val launch-msg = "Execute Stanza files directly using the Stanza virtual machine."
   defn launch-run (cmd-args:CommandArgs) :
@@ -799,10 +822,14 @@ defn run-command () :
                     get?(cmd-args, "macros", []))
 
   ;Command definition
-  Command("run",
-          AtLeastOneArg, "the .stanza/.proj input files or Stanza package names to execute in the virtual machine.",
-          flags,
-          launch-msg, intercept-no-match-exceptions(launch-run))
+  Command(
+    name = "run",
+    argtype = AtLeastOneArg,
+    arg-description = "the .stanza/.proj input files or Stanza package names to execute in the virtual machine.",
+    flags = flags,
+    description = launch-msg,
+    verify = verify-args,
+    action = intercept-no-match-exceptions(launch-run))
 
 ;============================================================
 ;==================== Run Test Command ======================

--- a/compiler/params.stanza
+++ b/compiler/params.stanza
@@ -18,7 +18,7 @@ public defn compiler-flags () :
   to-tuple(COMPILE-FLAGS)
 
 ;========= Stanza Configuration ========
-public val STANZA-VERSION = [0 18 28]
+public val STANZA-VERSION = [0 18 29]
 public var STANZA-INSTALL-DIR:String = ""
 public var OUTPUT-PLATFORM:Symbol = `platform
 public var STANZA-PKG-DIRS:List<String> = List()

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -10,6 +10,7 @@ defpackage stz/proj-manager :
   import stz/aux-file
   import stz/package-stamps
   import stz/file-stamps
+  import stz/verbose
 
 ;<doc>=======================================================
 ;=================== Project Manager ========================
@@ -157,7 +158,16 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
       (pkg-path:String, src-path:String) :
         match(auxfile:AuxFile) :
           if file-exists?(src-path) :
-            key?(auxfile, make-pkg-record(name, filestamp(pkg-path), filestamp(src-path)))
+            val pkg-rec = make-pkg-record(name, filestamp(pkg-path), filestamp(src-path))
+            vprintln("Check whether package %~ is up-to-date." % [name])
+            within indented() :
+              vprintln(pkg-rec)
+            val up-to-date? = key?(auxfile, pkg-rec)
+            if up-to-date? :
+              vprintln("Pkg file for package %~ at %~ is up-to-date." % [name, pkg-path])
+            else :
+              vprintln("Pkg file for package %~ at %~ is not up-to-date." % [name, pkg-path])
+            up-to-date?
       (pkg-path:String, src-path:False) : true
       (pkg-path:False, src-path) : false
     if pkg-path is-not False or src-path is-not False :


### PR DESCRIPTION
Add logging printouts to help debug slow builds.