### PR TITLE
Build command-line debugger and debug adapter

### DIFF
--- a/build-stanza.proj
+++ b/build-stanza.proj
@@ -1,4 +1,5 @@
 include "core/stanza.proj"
+include "core/debug/stanza.proj"
 include "compiler/stanza.proj"
 
 build main :
@@ -21,3 +22,27 @@ build core-macros :
     stz/macro-plugin
   o: "../build/core-macros"
   pkg: "../pkgs"
+
+build debugger :
+  inputs:
+    debugger
+  pkg: "pkgs"
+  o: "stanza-debugger"
+
+build debug-adapter :
+  inputs:
+    debug-adapter
+  ccfiles:
+    "core/debug/debug-adapter.c"
+  ccflags:
+    on-platform:
+      os-x :
+        "-DBUILD_DEBUG_ADAPTER"
+        "-D_XOPEN_SOURCE"
+      linux :
+        "-DBUILD_DEBUG_ADAPTER"
+        "-fPIC"
+      else : ()
+  pkg: "pkgs"
+  o: "debug-adapter"
+

--- a/build-stanza.proj
+++ b/build-stanza.proj
@@ -26,6 +26,8 @@ build core-macros :
 build debugger :
   inputs:
     debugger
+  ccfiles:
+    "core/debug/debugger.c"
   pkg: "pkgs"
   o: "stanza-debugger"
 

--- a/core/debug/debug-adapter.c
+++ b/core/debug/debug-adapter.c
@@ -1,0 +1,3559 @@
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef PLATFORM_WINDOWS
+  #include <fcntl.h>
+  #include <io.h>
+  #include <windows.h>
+#else
+  #include <sys/socket.h>
+  #include <netinet/in.h>
+  #include <unistd.h>
+  typedef int SOCKET;
+#endif
+
+static inline void* memclear(void* data, size_t size) {
+  return memset(data, 0, size);
+}
+static const char* current_error(void) {
+  return strerror(errno);
+}
+
+static FILE* debug_adapter_log;
+static pthread_mutex_t log_lock;
+static void log_printf(const char* fmt, ...) {
+  if (debug_adapter_log) {
+    pthread_mutex_lock(&log_lock);
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf (debug_adapter_log, fmt, args);
+    va_end(args);
+
+    pthread_mutex_unlock(&log_lock);
+  }
+}
+static void log_packet(const char* prefix, const char* data, size_t length) {
+  if (debug_adapter_log) {
+    pthread_mutex_lock(&log_lock);
+
+    fprintf(debug_adapter_log, "\n%s\nContent-Length: %" PRIu64 "\n\n", prefix, (uint64_t)length);
+    fwrite(data, length, 1, debug_adapter_log);
+    fprintf(debug_adapter_log, "\n");
+
+    pthread_mutex_unlock(&log_lock);
+  }
+}
+
+typedef struct {
+  size_t length;
+  size_t capacity;
+  char** data;
+} StringVector;
+static void StringVector_initialize(StringVector* vector) {
+  vector->length = 0;
+  vector->capacity = 16;
+  vector->data = malloc(vector->capacity * sizeof(char*));
+  //TODO: handle possible OOM
+}
+static void StringVector_destroy(StringVector* vector) {
+  char** data = vector->data;
+  int length = vector->length;
+  for (int i = 0; i < length; i++)
+    free(data[i]);
+  free(data);
+}
+static inline void StringVector_reset(StringVector* vector) {
+  vector->length = 0;
+}
+static void StringVector_append(StringVector* vector, const char* s) {
+  if (vector->length == vector->capacity) {
+    vector->capacity <<= 1;
+    vector->data = realloc(vector->data, vector->capacity * sizeof(char*));
+    //TODO: handle possible OOM
+  }
+  vector->data[vector->length++] = strdup(s);
+  //TODO: handle possible OOM
+}
+
+enum {
+  RUN_MODE_UNKNOWN,
+  RUN_MODE_RUNNING,
+  RUN_MODE_PAUSED,
+  RUN_MODE_TERMINATED,
+  RUN_MODE_STEP_IN,
+  RUN_MODE_STEP_OUT,
+  RUN_MODE_STEP_OVER
+};
+static uint8_t run_mode = RUN_MODE_UNKNOWN;
+
+enum {
+  INVALID_THREAD_ID = -1,
+  INVALID_FRAME_ID = 0
+};
+
+static char* program_path;
+static pid_t program_pid;
+static pthread_mutex_t send_lock;
+static bool stack_trace_available; // Stack trace is not available until VMState initialized
+static const char* debug_adapter_path;
+static const uint64_t thread_id = 12345678;
+
+// Client IDE capabilities
+static bool client_supports_invalidated_event;
+
+static inline char* get_absolute_path(const char* s) {
+  // Use GetFullPathName on Windows
+  return realpath(s, NULL);
+}
+static inline void free_path(const char* s) {
+  free((char*)s);
+}
+
+enum {
+  NOP = 0x90,
+  INT3 = 0xCC
+};
+
+typedef const struct {
+  uint8_t* const address;
+  const uint64_t group;
+} SafepointAddress;
+
+typedef const struct {
+  const uint64_t length;
+  SafepointAddress addresses[];
+} AddressList;
+static void AddressList_write(AddressList* list, const uint8_t inst) {
+  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
+    *p->address = inst;
+}
+static inline SafepointAddress* AddressList_find(AddressList* list, const void* pc) {
+  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
+    if (p->address == pc)
+      return p;
+  return NULL;
+}
+
+typedef const struct {
+  const uint64_t line;
+  AddressList* const address_list;
+} SafepointEntry;
+static inline void SafepointEntry_write(SafepointEntry* entry, const uint8_t inst) {
+  AddressList_write(entry->address_list, inst);
+}
+static SafepointAddress* SafepointEntry_find(SafepointEntry* entry, const void* pc) {
+  return AddressList_find(entry->address_list, pc);
+}
+
+typedef const struct {
+  const uint64_t num_entries;
+  const char* const filename;
+  SafepointEntry entries[];
+} FileSafepoints;
+static void FileSafepoints_write(FileSafepoints* file, const uint8_t inst) {
+  for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
+    SafepointEntry_write(entry, inst);
+}
+static inline SafepointEntry* FileSafepoints_find(FileSafepoints* file, uint64_t line) {
+  if (file)
+    for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
+      if (entry->line >= line)
+        return entry;
+  return NULL;
+}
+
+typedef const struct {
+  const uint64_t num_files;
+  FileSafepoints* const files[];
+} SafepointTable;
+SafepointTable* app_safepoint_table;
+static void Safepoints_write(const uint8_t inst) {
+  SafepointTable* safepoints = app_safepoint_table;
+  if (safepoints)
+    for (uint64_t i = 0, num_files = app_safepoint_table->num_files; i < num_files; i++)
+      FileSafepoints_write(safepoints->files[i], inst);
+}
+static FileSafepoints* Safepoints_find_file(const char* file_name) {
+  const char* file_path = get_absolute_path(file_name);
+  FileSafepoints* result = NULL;
+  if (file_path) {
+    SafepointTable* safepoints = app_safepoint_table;
+    if (safepoints) {
+      for (uint64_t i = 0, num_files = app_safepoint_table->num_files; i < num_files && !result; i++) {
+        FileSafepoints* p = safepoints->files[i];
+        const char* path = get_absolute_path(p->filename);
+        if (path && !strcmp(path, file_path))
+          result = p;
+        free_path(path);
+      }
+    }
+    free_path(file_path);
+  }
+  return result;
+}
+
+// For debugging only
+static void print_safepoint(const void* pc) {
+  SafepointTable* safepoints = app_safepoint_table;
+  if (safepoints) {
+    for (uint64_t i = 0, num_files = app_safepoint_table->num_files; i < num_files; i++) {
+      FileSafepoints* file = safepoints->files[i];
+      for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++) {
+        if (SafepointEntry_find(entry, pc)) {
+          log_printf("!!! Safepoint pc: %p file: %s line: %" PRIu64 "\n", pc, file->filename, entry->line);
+          return;
+        }
+      }
+    }
+  }
+  log_printf("!!! Safepoint not found for pc %p\n", pc);
+}
+
+typedef struct {
+  size_t length;
+  size_t capacity;
+  SafepointEntry** data;
+} SafepointEntryVector;
+static inline void SafepointEntryVector_initialize(SafepointEntryVector* v) {
+  v->length = 0;
+  v->capacity = 16; // Initial vector size
+  v->data = malloc(v->capacity * sizeof(v->data[0]));
+  //TODO: handle possible OOME
+}
+static inline void SafepointEntryVector_destroy(SafepointEntryVector* v) {
+  free(v->data);
+}
+static inline SafepointEntry** SafepointEntryVector_allocate(SafepointEntryVector* v) {
+  if (v->length == v->capacity) {
+    v->capacity <<= 1;
+    v->data = realloc(v->data, v->capacity * sizeof(v->data[0]));
+    //TODO: handle possible OOM
+  }
+  return v->data + v->length++;
+}
+static inline SafepointEntry** SafepointEntryVector_find(const SafepointEntryVector* v, SafepointEntry* entry) {
+  for (SafepointEntry **p = v->data, **lim = p + v->length; p < lim; p++)
+    if (*p == entry)
+      return p;
+  return NULL;
+}
+
+typedef struct ACTIVE_FILE_SAFEPOINTS {
+  struct ACTIVE_FILE_SAFEPOINTS* next;
+  FileSafepoints* file;
+  SafepointEntry* data[];
+} ActiveFileSafepoints;
+static ActiveFileSafepoints* active_file_safepoints;
+static inline void ActiveFileSafepoints_create(const FileSafepoints* file, const SafepointEntryVector* v) {
+  const size_t length = v->length;
+  if (length) {
+    ActiveFileSafepoints* p = malloc(sizeof(ActiveFileSafepoints) + (length+1)*sizeof(v->data[0]));
+    p->next = active_file_safepoints;
+    active_file_safepoints = p;
+    p->file = file;
+    p->data[length] = NULL;
+    memcpy(p->data, v->data, length*sizeof(v->data[0]));
+  }
+}
+static inline void ActiveFileSafepoints_destroy(const FileSafepoints* file) {
+  for (ActiveFileSafepoints **p = &active_file_safepoints, *q; (q = *p) != NULL; p = &q->next) {
+    if (q->file == file) {
+      *p = q->next;
+      free(q);
+      break;
+    }
+  }
+}
+static inline void ActiveFileSafepoints_restore(void) {
+  for (const ActiveFileSafepoints* p = active_file_safepoints; p; p = p->next)
+    for (SafepointEntry* const* entry = p->data; *entry; entry++)
+      SafepointEntry_write(*entry, INT3);
+}
+static inline SafepointEntry* ActiveFileSafepoints_find_entry(const void* pc) {
+  for (const ActiveFileSafepoints* p = active_file_safepoints; p; p = p->next)
+    for (SafepointEntry* const* entry = p->data; *entry; entry++)
+      if (SafepointEntry_find(*entry, pc))
+        return *entry;
+  return NULL;
+}
+
+static bool all_sefapoints_enabled;
+static pthread_mutex_t safepoint_lock;
+static void enable_all_safepoints(void) {
+  pthread_mutex_lock(&safepoint_lock);
+  if (!all_sefapoints_enabled) {
+    Safepoints_write(INT3);
+    all_sefapoints_enabled = true;
+  }
+  pthread_mutex_unlock(&safepoint_lock);
+}
+static inline void disable_all_safepoints(void) {
+  pthread_mutex_lock(&safepoint_lock);
+  if (all_sefapoints_enabled) {
+    Safepoints_write(NOP);
+    all_sefapoints_enabled = false;
+    ActiveFileSafepoints_restore();
+  }
+  pthread_mutex_unlock(&safepoint_lock);
+}
+
+// I/O interface and its implementation over files and sockets.
+// Note: I am not sure why is this necessary in LLDB.
+static ssize_t (*debug_adapter_read) (char* data, size_t length);
+static ssize_t (*debug_adapter_write) (const char* data, size_t length);
+
+static SOCKET debug_adapter_socket;
+static ssize_t read_from_socket(char* data, size_t length) {
+  const ssize_t bytes_received = recv(debug_adapter_socket, data, length, 0);
+#ifdef PLATFORM_WINDOWS
+  errno = WSAGetLastError();
+#endif
+  return bytes_received;
+}
+static ssize_t write_to_socket(const char* data, size_t length) {
+  const ssize_t bytes_sent = send(debug_adapter_socket, data, length, 0);
+#ifdef PLATFORM_WINDOWS
+  errno = WSAGetLastError();
+#endif
+  return bytes_sent;
+}
+
+static int debug_adapter_input_fd;
+static int debug_adapter_output_fd;
+static ssize_t read_from_file(char* data, size_t length) {
+  return read(debug_adapter_input_fd, data, length);
+}
+static ssize_t write_to_file(const char* data, size_t length) {
+  return write(debug_adapter_output_fd, data, length);
+}
+
+static void write_full(const char* data, size_t length) {
+  while (length) {
+    const ssize_t bytes_written = (*debug_adapter_write)(data, length);
+    if (bytes_written < 0) {
+      if (errno == EINTR || errno == EAGAIN)
+        continue;
+      log_printf("Error writing data\n");
+      return;
+    }
+    assert(((unsigned)bytes_written) <= ((unsigned)length));
+    data += bytes_written;
+    length -= bytes_written;
+  }
+}
+
+static bool read_full(char* data, size_t length) {
+  while (length) {
+    const ssize_t bytes_read = (*debug_adapter_read)(data, length);
+    if (bytes_read == 0) {
+      log_printf("End of file (EOF) reading from input file\n");
+      return false;
+    }
+    if (bytes_read < 0) {
+      if (errno == EINTR || errno == EAGAIN)
+        continue;
+      log_printf("Error reading data\n");
+      return false;
+    }
+
+    assert(((unsigned)bytes_read) <= ((unsigned)length));
+    data += bytes_read;
+    length -= bytes_read;
+  }
+  return true;
+}
+
+static void write_string(const char* s) {
+  write_full(s, strlen(s));
+}
+static inline void write_unsigned(const unsigned long long v) {
+  char buffer[22];
+  snprintf(buffer, sizeof buffer, "%llu", v);
+  write_string(buffer);
+}
+static inline void write_packet(const char* data, const size_t length) {
+  pthread_mutex_lock(&send_lock);
+
+  write_string("Content-Length: ");
+  write_unsigned(length);
+  write_string("\r\n\r\n");
+  write_full(data, length);
+
+  log_packet("<--", data, length);
+
+  pthread_mutex_unlock(&send_lock);
+}
+
+static bool read_expected(const char* expected) {
+  char buffer[32];
+  size_t length = strlen(expected);
+  return read_full(buffer, length) && memcmp(buffer, expected, length) == 0;
+}
+static inline size_t read_unsigned(void) {
+  char buffer[32];
+  int count = 0;
+  char c;
+  do {
+    if (!read_full(&c, sizeof c)) return 0;
+    if (count < sizeof buffer)
+      buffer[count++] = c;
+  } while (c != '\r');
+
+  if (!read_full(&c, sizeof c)) return 0;
+  if (c == '\n') {
+    if (count > sizeof buffer) return 0;
+    char* remainder;
+    unsigned long value = strtoul(buffer, &remainder, 10); // Decimal only
+    if (*remainder == '\r') return value;
+  }
+  return 0;
+}
+
+static inline ssize_t read_packet(char** p_data) {
+  *p_data = NULL;
+  if (!read_expected("Content-Length: ")) {
+    log_printf("Content-Length not found\n");
+    return 0;
+  }
+  ssize_t length = read_unsigned();
+  if (!read_expected("\r\n")) return 0;
+  if (!length) {
+    log_printf("Zero-length content\n");
+    return 0;
+  }
+
+  char* data = malloc(length + 1); // For extra `\0' at the end
+  *p_data = data;
+  if (!data) {
+    log_printf("Cannot allocate %ld-byte content\n", (long) length);
+    return 0;
+  }
+  if (!read_full(data, length)) {
+    log_printf("Failed to read %ld-byte content\n", (long) length);
+    return 0;
+  }
+  data[length] = 0;
+  log_packet("-->", data, length);
+  return length;
+}
+
+typedef enum {
+  JS_NULL,
+  JS_BOOLEAN,
+  JS_INTEGER,
+  JS_DOUBLE,
+  JS_STRING,
+  JS_OBJECT,
+  JS_ARRAY
+} JSValueKind;
+
+typedef struct {
+  struct JS_FIELD* fields;
+} JSObject;
+
+typedef struct {
+  size_t length;
+  size_t capacity;
+  struct JS_VALUE* data;
+} JSArray;
+
+typedef struct JS_VALUE {
+  JSValueKind kind;
+  union {
+    bool b;
+    int64_t i;
+    double d;
+    const char* s;
+    JSObject o;
+    JSArray a;
+  } u;
+} JSValue;
+
+// Initialize the value as JS_NULL. Later it can be safely
+// re-initialized as any other kind.
+static inline JSValue* JSValue_initialize(JSValue* value) {
+  value->kind = JS_NULL;
+  return value;
+}
+static void JSValue_destroy(JSValue* value);
+
+static inline void JSValue_make_boolean(JSValue* value, bool b) {
+  value->kind = JS_BOOLEAN;
+  value->u.b = b;
+}
+static inline void JSValue_make_integer(JSValue* value, int64_t i) {
+  value->kind = JS_INTEGER;
+  value->u.i = i;
+}
+static inline void JSValue_make_double(JSValue* value, double d) {
+  value->kind = JS_DOUBLE;
+  value->u.d = d;
+}
+// Strings are zero-terminated. Consider (data, length) pairs if strings need to contain `\0's.
+// JSValue is not resposible for string deallocation.
+static inline void JSValue_make_string(JSValue* value, const char* s) {
+  value->kind = JS_STRING;
+  value->u.s = s;
+}
+
+static inline JSArray* JSArray_initialize(JSArray* array) {
+  array->length = 0;
+  array->capacity = 16; // Initial array size
+  array->data = malloc(array->capacity * sizeof(JSValue));
+  //TODO: handle possible OOME
+  return array;
+}
+static inline void JSArray_destroy(JSArray* array) {
+  JSValue* data = array->data;
+  const JSValue* limit = data + array->length;
+  JSValue* p = data;
+  for (JSValue* p = data; p < limit; p++)
+    JSValue_destroy(p);
+  free(data);
+}
+static inline JSArray* JSValue_make_array(JSValue* value) {
+  value->kind = JS_ARRAY;
+  return JSArray_initialize(&value->u.a);
+}
+static inline JSValue* JSArray_append(JSArray* array) {
+  if (array->length == array->capacity) {
+    array->capacity <<= 1;
+    array->data = realloc(array->data, array->capacity * sizeof(JSValue));
+    //TODO: handle possible OOM
+  }
+  // Only initialized values can be destroyed.
+  return JSValue_initialize(array->data + array->length++);
+}
+
+typedef struct JS_FIELD {
+  struct JS_FIELD* next;
+  const char* name;
+  JSValue value;
+} JSField;
+static JSField* JSField_find(JSObject* object, const char* name) {
+  JSField* field;
+  for (field = object->fields; field && strcmp(field->name, name); field = field->next);
+  return field;
+}
+static inline JSField* JSField_create(JSObject* object, const char* name) {
+  JSField* field = JSField_find(object, name);
+  if (field) {
+    JSValue_destroy(&field->value);
+  } else {
+    field = malloc(sizeof *field);
+    //TODO: handle possible OOM
+    field->name = name;
+    field->next = object->fields;
+    object->fields = field;
+  }
+  JSValue_initialize(&field->value);
+  return field;
+}
+static inline JSField* JSField_destroy(JSField* field) {
+  JSField* next = field->next;
+  JSValue_destroy(&field->value);
+  free(field);
+  return next;
+}
+static const JSField* JSObject_get_field(const JSObject* object, const char* name, const JSValueKind kind) {
+  if (object) {
+    const JSField* field = JSField_find((JSObject*)object, name);
+    if (field && field->value.kind == kind)
+      return field;
+  }
+  return NULL;
+}
+static const char* JSObject_get_string_field(const JSObject* object, const char* name) {
+  const JSField* field = JSObject_get_field(object, name, JS_STRING);
+  return field ? field->value.u.s : NULL;
+}
+static const JSObject* JSObject_get_object_field(const JSObject* object, const char* name) {
+  const JSField* field = JSObject_get_field(object, name, JS_OBJECT);
+  return field ? &field->value.u.o : NULL;
+}
+static const JSArray* JSObject_get_array_field(const JSObject* object, const char* name) {
+  const JSField* field = JSObject_get_field(object, name, JS_ARRAY);
+  return field ? &field->value.u.a : NULL;
+}
+static int64_t JSObject_get_integer_field(const JSObject* object, const char* name, int64_t default_value) {
+  const JSField* field = JSObject_get_field(object, name, JS_INTEGER);
+  return field ? field->value.u.i : default_value;
+}
+static int64_t JSObject_get_bool_field(const JSObject* object, const char* name, bool default_value) {
+  const JSField* field = JSObject_get_field(object, name, JS_BOOLEAN);
+  return field ? field->value.u.b : default_value;
+}
+
+static inline JSObject* JSObject_initialize(JSObject* object) {
+  object->fields = NULL;
+  return object;
+}
+static inline void JSObject_destroy(JSObject* object) {
+  for (JSField* field = object->fields; field; field = JSField_destroy(field));
+}
+static inline JSObject* JSValue_make_object(JSValue* value) {
+  value->kind = JS_OBJECT;
+  return JSObject_initialize(&value->u.o);
+}
+
+static void JSValue_destroy(JSValue* value) {
+  switch (value->kind) {
+    case JS_OBJECT: JSObject_destroy(&value->u.o); break;
+    case JS_ARRAY: JSArray_destroy(&value->u.a); break;
+  }
+}
+
+
+typedef struct {
+  const char* start;
+  const char* limit;
+  const char* p;
+  char error[256];
+} JSParser;
+
+static inline void JSParser_initialize(JSParser* parser, const char* data, size_t length) {
+  parser->start = data;
+  parser->p = data;
+  parser->limit = data + length;
+  parser->error[0] = '\0';
+}
+
+// Returns false for convenience.
+static bool JSParser_error(JSParser* parser, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(parser->error, sizeof(parser->error), fmt, args);
+  va_end(args);
+  return false;
+}
+
+static const char* JSParser_skip_spaces(JSParser* parser) {
+  const char* p = parser->p;
+  while (isspace(*p)) p++;
+  parser->p = p;
+  return p;
+}
+
+static char JSParser_next(JSParser* parser) {
+  if (parser->p < parser->limit)
+    return *parser->p++;
+  return '\0';
+}
+
+static bool JSParser_expect(JSParser* parser, const char* s) {
+  size_t length = strlen(s) - 1; // First character has already matched
+  if (!memcmp(parser->p, s + 1, length)) { // Parser text buffer is zero-terminated
+    parser->p += length;
+    return true;
+  }
+  return JSParser_error(parser, "Invalid JSON value (%s?)", s);
+}
+
+static bool JSParser_at_end(JSParser* parser) {
+  return JSParser_skip_spaces(parser) == parser->limit;
+}
+
+static bool is_numeric(char c) {
+  return isdigit(c) || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E';
+}
+
+static bool JSParser_parse_value(JSParser* parser, JSValue* value) {
+  if (JSParser_at_end(parser))
+    return JSParser_error(parser, "Unexpected end-of-file");
+
+  const char c = JSParser_next(parser);
+  switch (c) {
+    case 'n': // null
+      return JSParser_expect(parser, "null");
+    case 't': // true
+      JSValue_make_boolean(value, true);
+      return JSParser_expect(parser, "true");
+    case 'f': // false
+      JSValue_make_boolean(value, false);
+      return JSParser_expect(parser, "false");
+    case '"': { // string
+      JSValue_make_string(value, parser->p);
+      // Zero-terminated string is always shorter than its external representation
+      // therefore it can be created in the parser buffer.
+      char* p = (char*) parser->p;
+      for (unsigned char c; (c = JSParser_next(parser)) != '"'; *p++ = c) {
+        if (c < ' ')
+          return JSParser_error(parser, parser->p == parser->limit ? "Unterminated string" : "Unescaped control character in string");
+        if (c != '\\') continue;
+        c = JSParser_next(parser);
+        switch (c) {
+          case '"':
+          case '\\':
+          case '/': continue;
+          case 'b': c = '\b'; continue;
+          case 'f': c = '\f'; continue;
+          case 'n': c = '\n'; continue;
+          case 'r': c = '\r'; continue;
+          case 't': c = '\t'; continue;
+        }
+        return JSParser_error(parser, "Hex and unicode escape sequences are not yet supported");
+      }
+      *p = '\0';
+      return true;
+    }
+    case '{': // object
+      for (JSObject* object = JSValue_make_object(value); *JSParser_skip_spaces(parser) != '}';) {
+        if (object->fields && *parser->p++ != ',')
+          return JSParser_error(parser, "Expected , or } after object property");
+        if (*JSParser_skip_spaces(parser) != '"')
+          return JSParser_error(parser, "Expected object key");
+        parser->p++; // Skip '"'
+        const char* name = parser->p;
+        for (char c; (c = JSParser_next(parser)) != '"';)
+          if (!c) return JSParser_error(parser, "Unterminated key");
+        *(char*)(parser->p - 1) = '\0';
+        if (*JSParser_skip_spaces(parser) != ':')
+          return JSParser_error(parser, "Expected : after object key");
+        parser->p++; // Skip ':'
+        JSParser_parse_value(parser, &JSField_create(object, name)->value);
+      }
+      parser->p++; // Skip '}'
+      return true;
+    case '[': // array
+      for (JSArray* array = JSValue_make_array(value); *JSParser_skip_spaces(parser) != ']';) {
+        if (array->length && *parser->p++ != ',')
+          return JSParser_error(parser, "Expected , or ] after array element");
+        JSParser_parse_value(parser, JSArray_append(array));
+      }
+      parser->p++; // Skip ']'
+      return true;
+    default:
+      if (is_numeric(c)) {
+        const char* start = parser->p - 1;
+        const char* p = start;
+        while (is_numeric(*++p)); // Skip the number
+        parser->p = p;
+
+        char* end;
+        int64_t i = strtoll(start, &end, 10);
+        // On overflow strtoll caps the result by INT64_MIN and INT64_MAX
+        if (end == p && i > INT64_MIN && i < INT64_MAX) {
+          JSValue_make_integer(value, i);
+          return true;
+        }
+        double d = strtod(start, &end);
+        if (end == p) {
+          JSValue_make_double(value, d);
+          return true;
+        }
+      }
+      return JSParser_error(parser, "Invalid JSON value");
+  }
+  return false;
+}
+
+typedef struct {
+  size_t length;
+  size_t capacity;
+  char* data;
+  int indent;
+  uint64_t nexts;  // Stack of bit nexts of nested lists
+} JSBuilder;
+static inline void JSBuilder_initialize(JSBuilder* builder) {
+  builder->indent = 0;
+  builder->nexts = 0;
+  builder->length = 0;
+  builder->capacity = 16*1024; // Initial buffer size
+  builder->data = malloc(builder->capacity);
+  //TODO: handle possible OOME
+}
+static inline void JSBuilder_destroy(JSBuilder* builder) {
+  free(builder->data);
+}
+static inline void JSBuilder_send_and_destroy(JSBuilder* builder) {
+  write_packet(builder->data, builder->length);
+  JSBuilder_destroy(builder);
+}
+
+// Bit stack manipulations.
+static inline uint64_t JSBuilder_set_next(JSBuilder* builder) {
+  const uint64_t nexts = builder->nexts;
+  builder->nexts |= 1;
+  return nexts & 1;
+}
+static inline void JSBuilder_push_nexts(JSBuilder* builder) {
+  assert(((int64_t)builder->nexts) >= 0);
+  builder->nexts <<= 1;
+}
+static inline void JSBuilder_pop_nexts(JSBuilder* builder) {
+  builder->nexts >>= 1;
+}
+
+static void JSBuilder_ensure_capacity(JSBuilder* builder, size_t size) {
+  size_t capacity = builder->capacity;
+  const size_t length = builder->length;
+  const size_t required_capacity = length + size;
+  if (required_capacity <= capacity) return;
+
+  while (capacity < required_capacity)
+    capacity <<= 1;
+  builder->capacity = capacity;
+
+  char* data = builder->data;
+  builder->data = memcpy(malloc(capacity), data, length);
+  //TODO: handle possible OOM
+  free(data);
+}
+static char* JSBuilder_allocate(JSBuilder* builder, size_t size) {
+  JSBuilder_ensure_capacity(builder, size);
+  char* data = builder->data + builder->length;
+  builder->length += size;
+  return data;
+}
+static void JSBuilder_append_char(JSBuilder* builder, char c) {
+  JSBuilder_allocate(builder, 1)[0] = c;
+}
+static void JSBuilder_append_text(JSBuilder* builder, const char* data, size_t length) {
+  if (length)
+    memcpy(JSBuilder_allocate(builder, length), data, length);
+}
+static void JSBuilder_append_string(JSBuilder* builder, const char* s) {
+  JSBuilder_append_text(builder, s, strlen(s));
+}
+static void JSBuilder_append_unsigned(JSBuilder* builder, uint64_t v) {
+  char buffer[22];
+  snprintf(buffer, sizeof buffer, "%" PRIu64, v);
+  JSBuilder_append_string(builder, buffer);
+}
+static inline void JSBuilder_append_bool(JSBuilder* builder, bool v) {
+  JSBuilder_append_string(builder, v ? "true" : "false");
+}
+
+static void JSBuilder_append_null(JSBuilder* builder) {
+  JSBuilder_append_string(builder, "null");
+}
+static void JSBuilder_append_quotes(JSBuilder* builder) {
+  JSBuilder_append_char(builder, '\"');
+}
+static void JSBuilder_write_quoted_raw_string(JSBuilder* builder, const char* s) {
+  JSBuilder_append_quotes(builder);
+  JSBuilder_append_string(builder, s);
+  JSBuilder_append_quotes(builder);
+}
+static inline char hex_nybble(char c) {
+  return "0123456789ABCDEF"[c & 0xF];
+}
+static void JSBuilder_write_quoted_text(JSBuilder* builder, const char* data, size_t length) {
+  JSBuilder_append_quotes(builder);
+  for (const char* limit = data + length;;) {
+    const char* p = data;
+    for (; p < limit; p++) {
+      const unsigned char c = *p;
+      if (c < ' ' || c == '\"' || c == '\\')
+        break;
+    }
+    JSBuilder_append_text(builder, data, p - data);
+    data = p;
+    if (data == limit) break;
+
+    char* s = JSBuilder_allocate(builder, 2);
+    *s++ = '\\';
+
+    const unsigned char c = *data++;
+    switch (c) {
+      case '\"': *s = '\"'; break;
+      case '\\': *s = '\\'; break;
+      case '\b': *s = 'b'; break;
+      case '\f': *s = 'f'; break;
+      case '\t': *s = 't'; break;
+      case '\n': *s = 'n'; break;
+      case '\r': *s = 'r'; break;
+      default:
+        *s = 'u';
+        s = JSBuilder_allocate(builder, 4);
+        s[3] = hex_nybble(c >> 0);
+        s[2] = hex_nybble(c >> 4);
+        s[1] = hex_nybble(c >> 8);
+        s[0] = hex_nybble(c >> 12);
+    }
+  }
+  JSBuilder_append_quotes(builder);
+}
+static void JSBuilder_write_quoted_string(JSBuilder* builder, const char* s) {
+  if (s)
+    JSBuilder_write_quoted_text(builder, s, strlen(s));
+  else
+    JSBuilder_append_null(builder);
+}
+
+enum { JSIndentStep = 2 };
+static inline void JSBuilder_indent(JSBuilder* builder) {
+  builder->indent += JSIndentStep;
+  JSBuilder_push_nexts(builder);
+}
+static inline void JSBuilder_unindent(JSBuilder* builder) {
+  builder->indent -= JSIndentStep;
+  assert(builder->indent >= 0);
+  JSBuilder_pop_nexts(builder);
+}
+static void JSBuilder_newline(JSBuilder* builder) {
+  int chars_to_append = builder->indent + 1;
+  char* data = JSBuilder_allocate(builder, chars_to_append);
+  *data++ = '\n';
+  while (--chars_to_append > 0)
+    *data++ = ' ';
+}
+
+static inline void JSBuilder_next(JSBuilder* builder) {
+  if (JSBuilder_set_next(builder))
+    JSBuilder_append_char(builder, ',');
+  JSBuilder_newline(builder);
+}
+
+static void JSBuilder_write_field(JSBuilder* builder, const char* name) {
+  JSBuilder_next(builder);
+  JSBuilder_write_quoted_raw_string(builder, name);
+  JSBuilder_append_string(builder, ": ");
+}
+static void JSBuilder_write_raw_string_field(JSBuilder* builder, const char* name, const char* value) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_write_quoted_raw_string(builder, value);
+}
+static void JSBuilder_write_optional_raw_string_field(JSBuilder* builder, const char* name, const char* value) {
+  if (value) JSBuilder_write_raw_string_field(builder, name, value);
+}
+static void JSBuilder_write_string_field(JSBuilder* builder, const char* name, const char* value) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_write_quoted_string(builder, value);
+}
+static void JSBuilder_write_optional_string_field(JSBuilder* builder, const char* name, const char* value) {
+  if (value) JSBuilder_write_string_field(builder, name, value);
+}
+static void JSBuilder_write_unsigned_field(JSBuilder* builder, const char* name, uint64_t value) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_append_unsigned(builder, value);
+}
+static void JSBuilder_write_optional_unsigned_field(JSBuilder* builder, const char* name, uint64_t value) {
+  if (value) JSBuilder_write_unsigned_field(builder, name, value);
+}
+static void JSBuilder_write_bool_field(JSBuilder* builder, const char* name, bool value) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_append_bool(builder, value);
+}
+
+static inline void JSBuilder_structure_begin(JSBuilder* builder, char brace) {
+  JSBuilder_append_char(builder, brace);
+  JSBuilder_indent(builder);
+}
+static inline void JSBuilder_structure_end(JSBuilder* builder, char brace) {
+  JSBuilder_unindent(builder);
+  JSBuilder_newline(builder);
+  JSBuilder_append_char(builder, brace);
+}
+static void JSBuilder_object_begin(JSBuilder* builder) {
+  JSBuilder_structure_begin(builder, '{');
+}
+static void JSBuilder_object_end(JSBuilder* builder) {
+  JSBuilder_structure_end(builder, '}');
+}
+static void JSBuilder_array_begin(JSBuilder* builder) {
+  JSBuilder_structure_begin(builder, '[');
+}
+static void JSBuilder_array_end(JSBuilder* builder) {
+  JSBuilder_structure_end(builder, ']');
+}
+static void JSBuilder_object_field_begin(JSBuilder* builder, const char* name) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_object_begin(builder);
+}
+static inline void JSBuilder_object_field_end(JSBuilder* builder) {
+  JSBuilder_object_end(builder);
+}
+static void JSBuilder_array_field_begin(JSBuilder* builder, const char* name) {
+  JSBuilder_write_field(builder, name);
+  JSBuilder_array_begin(builder);
+}
+static inline void JSBuilder_array_field_end(JSBuilder* builder) {
+  JSBuilder_array_end(builder);
+}
+
+static void JSBuilder_send_and_destroy_object(JSBuilder* builder) {
+  JSBuilder_object_end(builder);
+  JSBuilder_send_and_destroy(builder);
+}
+
+static void JSBuilder_write_seq_0(JSBuilder* builder) {
+  JSBuilder_write_field(builder, "seq"); JSBuilder_append_char(builder, '0');
+}
+static void JSBuilder_initialize_simple_event(JSBuilder* builder, const char* name) {
+  JSBuilder_initialize(builder);
+  JSBuilder_object_begin(builder);
+  JSBuilder_write_seq_0(builder);
+  JSBuilder_write_raw_string_field(builder, "type", "event");
+  JSBuilder_write_raw_string_field(builder, "event", name);
+}
+static inline void JSBuilder_send_and_destroy_simple_event(JSBuilder* builder) {
+  JSBuilder_send_and_destroy_object(builder);
+}
+static void send_simple_event(const char* name) {
+  JSBuilder builder;
+  JSBuilder_initialize_simple_event(&builder, name);
+  JSBuilder_send_and_destroy_simple_event(&builder);
+}
+
+static void JSBuilder_initialize_event(JSBuilder* builder, const char* name) {
+  JSBuilder_initialize_simple_event(builder, name);
+  JSBuilder_object_field_begin(builder, "body");
+}
+static void JSBuilder_send_and_destroy_event(JSBuilder* builder) {
+  JSBuilder_object_end(builder); // body
+  JSBuilder_send_and_destroy_simple_event(builder);
+}
+
+// "StoppedEvent": {
+//   "allOf": [ { "$ref": "#/definitions/Event" }, {
+//     "type": "object",
+//     "description": "Event message for 'stopped' event type. The event
+//                     indicates that the execution of the debuggee has stopped
+//                     due to some condition. This can be caused by a break
+//                     point previously set, a stepping action has completed,
+//                     by executing a debugger statement etc.",
+//     "properties": {
+//       "event": {
+//         "type": "string",
+//         "enum": [ "stopped" ]
+//       },
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "reason": {
+//             "type": "string",
+//             "description": "The reason for the event. For backward
+//                             compatibility this string is shown in the UI if
+//                             the 'description' attribute is missing (but it
+//                             must not be translated).",
+//             "_enum": [ "step", "breakpoint", "exception", "pause", "entry" ]
+//           },
+//           "description": {
+//             "type": "string",
+//             "description": "The full reason for the event, e.g. 'Paused
+//                             on exception'. This string is shown in the UI
+//                             as is."
+//           },
+//           "threadId": {
+//             "type": "integer",
+//             "description": "The thread which was stopped."
+//           },
+//           "text": {
+//             "type": "string",
+//             "description": "Additional information. E.g. if reason is
+//                             'exception', text contains the exception name.
+//                             This string is shown in the UI."
+//           },
+//           "allThreadsStopped": {
+//             "type": "boolean",
+//             "description": "If allThreadsStopped is true, a debug adapter
+//                             can announce that all threads have stopped.
+//                             The client should use this information to
+//                             enable that all threads can be expanded to
+//                             access their stacktraces. If the attribute
+//                             is missing or false, only the thread with the
+//                             given threadId can be expanded."
+//           }
+//         },
+//         "required": [ "reason" ]
+//       }
+//     },
+//     "required": [ "event", "body" ]
+//   }]
+// }
+typedef enum { // Extendable - please add custom stop reasons as necessary.
+  STOP_REASON_STEP,
+  STOP_REASON_BREAKPOINT,
+  STOP_REASON_EXCEPTION,
+  STOP_REASON_PAUSE,
+  STOP_REASON_ENTRY
+} StopReason;
+static inline const char* stop_reason(const StopReason kind) {
+  static const char* const names[] = {
+    "step",
+    "breakpoint",
+    "exception",
+    "pause",
+    "entry"
+  };
+  return names[kind];
+}
+
+static inline void send_invalidate_thread(void) {
+  if (client_supports_invalidated_event) {
+    JSBuilder builder;
+    JSBuilder_initialize_event(&builder, "invalidated");
+    JSBuilder_write_unsigned_field(&builder, "threadId", thread_id);
+    JSBuilder_send_and_destroy_event(&builder);
+  }
+}
+
+static void send_thread_stopped(StopReason reason, const char* description, uint64_t breakpoint) {
+  //send_invalidate_thread();
+  run_mode = RUN_MODE_PAUSED;
+
+  JSBuilder builder;
+  JSBuilder_initialize_event(&builder, "stopped");
+  JSBuilder_write_raw_string_field(&builder, "reason", stop_reason(reason));
+  if (description)
+    JSBuilder_write_raw_string_field(&builder, "description", description);
+  if (breakpoint) {
+    JSBuilder_array_field_begin(&builder, "hitBreakpointIds");
+    {
+      JSBuilder_next(&builder);
+      JSBuilder_append_unsigned(&builder, breakpoint);
+    }
+    JSBuilder_array_field_end(&builder);
+  }
+  JSBuilder_write_unsigned_field(&builder, "threadId", thread_id);
+  JSBuilder_write_bool_field(&builder, "allThreadsStopped", true);
+  //JSBuilder_write_bool_field(&builder, "preserveFocusHint", false);
+  //JSBuilder_write_bool_field(&builder, "threadCausedFocus", true);
+  JSBuilder_send_and_destroy_event(&builder);
+}
+
+static inline void send_process_exited(uint64_t exit_code) {
+  run_mode = RUN_MODE_TERMINATED;
+
+  JSBuilder builder;
+  JSBuilder_initialize_event(&builder, "exited");
+  JSBuilder_write_unsigned_field(&builder, "exitCode", exit_code);
+  JSBuilder_send_and_destroy_event(&builder);
+}
+
+static inline void send_terminated(void) {
+  if (run_mode != RUN_MODE_TERMINATED) {
+    run_mode = RUN_MODE_TERMINATED;
+    send_simple_event("terminated");
+  }
+}
+
+// "ProcessEvent": {
+//   "allOf": [
+//     { "$ref": "#/definitions/Event" },
+//     {
+//       "type": "object",
+//       "description": "Event message for 'process' event type. The event
+//                       indicates that the debugger has begun debugging a
+//                       new process. Either one that it has launched, or one
+//                       that it has attached to.",
+//       "properties": {
+//         "event": {
+//           "type": "string",
+//           "enum": [ "process" ]
+//         },
+//         "body": {
+//           "type": "object",
+//           "properties": {
+//             "name": {
+//               "type": "string",
+//               "description": "The logical name of the process. This is
+//                               usually the full path to process's executable
+//                               file. Example: /home/myproj/program.js."
+//             },
+//             "systemProcessId": {
+//               "type": "integer",
+//               "description": "The system process id of the debugged process.
+//                               This property will be missing for non-system
+//                               processes."
+//             },
+//             "isLocalProcess": {
+//               "type": "boolean",
+//               "description": "If true, the process is running on the same
+//                               computer as the debug adapter."
+//             },
+//             "startMethod": {
+//               "type": "string",
+//               "enum": [ "launch", "attach", "attachForSuspendedLaunch" ],
+//               "description": "Describes how the debug engine started
+//                               debugging this process.",
+//               "enumDescriptions": [
+//                 "Process was launched under the debugger.",
+//                 "Debugger attached to an existing process.",
+//                 "A project launcher component has launched a new process in
+//                  a suspended state and then asked the debugger to attach."
+//               ]
+//             }
+//           },
+//           "required": [ "name" ]
+//         }
+//       },
+//       "required": [ "event", "body" ]
+//     }
+//   ]
+// }
+static inline void send_process_launched(void) {
+  JSBuilder builder;
+  JSBuilder_initialize_event(&builder, "process");
+  JSBuilder_write_string_field(&builder, "name", program_path);
+  JSBuilder_write_unsigned_field(&builder, "systemProcessId", program_pid);
+  JSBuilder_write_bool_field(&builder, "isLocalProcess", true);
+  JSBuilder_write_raw_string_field(&builder, "startMethod", "launch");
+  JSBuilder_send_and_destroy_event(&builder);
+}
+
+// "Breakpoint": {
+//   "type": "object",
+//   "description": "Information about a Breakpoint created in setBreakpoints
+//                   or setFunctionBreakpoints.",
+//   "properties": {
+//     "id": {
+//       "type": "integer",
+//       "description": "An optional unique identifier for the breakpoint."
+//     },
+//     "verified": {
+//       "type": "boolean",
+//       "description": "If true breakpoint could be set (but not necessarily
+//                       at the desired location)."
+//     },
+//     "message": {
+//       "type": "string",
+//       "description": "An optional message about the state of the breakpoint.
+//                       This is shown to the user and can be used to explain
+//                       why a breakpoint could not be verified."
+//     },
+//     "source": {
+//       "$ref": "#/definitions/Source",
+//       "description": "The source where the breakpoint is located."
+//     },
+//     "line": {
+//       "type": "integer",
+//       "description": "The start line of the actual range covered by the
+//                       breakpoint."
+//     },
+//     "column": {
+//       "type": "integer",
+//       "description": "An optional start column of the actual range covered
+//                       by the breakpoint."
+//     },
+//     "endLine": {
+//       "type": "integer",
+//       "description": "An optional end line of the actual range covered by
+//                       the breakpoint."
+//     },
+//     "endColumn": {
+//       "type": "integer",
+//       "description": "An optional end column of the actual range covered by
+//                       the breakpoint. If no end line is given, then the end
+//                       column is assumed to be in the start line."
+//     }
+//   },
+//   "required": [ "verified" ]
+// }
+
+// 'verified' means the breakpoint can be set, though its location can be different from the desired.
+// If 'file' == null the breakpoint source location is omitted.
+// If 'path' == null the source path is omitted.
+// If 'line' is zero it is omitted.
+static void JSBuilder_write_breakpoint(JSBuilder* builder, uint64_t id, bool verified, const char* path, uint64_t line, uint64_t column) {
+  JSBuilder_object_begin(builder);
+  JSBuilder_write_unsigned_field(builder, "id", id);
+  JSBuilder_write_bool_field(builder, "verified", verified);
+  if (path) {
+    JSBuilder_write_field(builder, "source");
+    JSBuilder_object_begin(builder);
+    JSBuilder_write_string_field(builder, "path", path);
+    // TODO: In addition to "path" LLDB sets "name" field to basename(path)
+    JSBuilder_object_end(builder);
+    JSBuilder_write_optional_unsigned_field(builder, "line", line);
+    JSBuilder_write_optional_unsigned_field(builder, "column", column);
+  }
+  JSBuilder_object_end(builder);
+}
+static void send_breakpoint_changed(uint64_t id, bool verified) {
+  JSBuilder builder;
+  JSBuilder_initialize_event(&builder, "breakpoint");
+  JSBuilder_write_field(&builder, "breakpoint");
+  // Emit brief breakpoint info without source location
+  JSBuilder_write_breakpoint(&builder, id, verified, NULL, 0, 0);
+  JSBuilder_write_raw_string_field(&builder, "reason", "changed");
+  JSBuilder_send_and_destroy_event(&builder);
+}
+
+// "OutputEvent": {
+//   "allOf": [ { "$ref": "#/definitions/Event" }, {
+//     "type": "object",
+//     "description": "Event message for 'output' event type. The event
+//                     indicates that the target has produced some output.",
+//     "properties": {
+//       "event": {
+//         "type": "string",
+//         "enum": [ "output" ]
+//       },
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "category": {
+//             "type": "string",
+//             "description": "The output category. If not specified,
+//                             'console' is assumed.",
+//             "_enum": [ "console", "stdout", "stderr", "telemetry" ]
+//           },
+//           "output": {
+//             "type": "string",
+//             "description": "The output to report."
+//           },
+//           "variablesReference": {
+//             "type": "number",
+//             "description": "If an attribute 'variablesReference' exists
+//                             and its value is > 0, the output contains
+//                             objects which can be retrieved by passing
+//                             variablesReference to the VariablesRequest."
+//           },
+//           "source": {
+//             "$ref": "#/definitions/Source",
+//             "description": "An optional source location where the output
+//                             was produced."
+//           },
+//           "line": {
+//             "type": "integer",
+//             "description": "An optional source location line where the
+//                             output was produced."
+//           },
+//           "column": {
+//             "type": "integer",
+//             "description": "An optional source location column where the
+//                             output was produced."
+//           },
+//           "data": {
+//             "type":["array","boolean","integer","null","number","object",
+//                     "string"],
+//             "description": "Optional data to report. For the 'telemetry'
+//                             category the data will be sent to telemetry, for
+//                             the other categories the data is shown in JSON
+//                             format."
+//           }
+//         },
+//         "required": ["output"]
+//       }
+//     },
+//     "required": [ "event", "body" ]
+//   }]
+// }
+typedef enum {
+  CONSOLE,
+  STDOUT,
+  STDERR,
+  TELEMETRY
+} OutputType;
+
+static inline const char* output_category(const OutputType type) {
+  static const char* const names[] = {
+    "console",
+    "stdout",
+    "stderr",
+    "telemetry"
+  };
+  return names[type];
+}
+
+static void send_output(const OutputType out, const char* data, size_t length) {
+  assert(length > 0);
+  JSBuilder builder;
+  JSBuilder_initialize_event(&builder, "output");
+  JSBuilder_write_raw_string_field(&builder, "category", output_category(out));
+  JSBuilder_write_field(&builder, "output");
+  JSBuilder_write_quoted_text(&builder, data, length);
+  JSBuilder_send_and_destroy_event(&builder);
+}
+
+static void* redirect_output_loop(void* args) {
+  const int read_fd = ((int*)args)[0];
+  const OutputType out = ((int*)args)[1];
+  free(args);
+
+  while (true) {
+    char buffer[4096];
+    const int bytes_read = read(read_fd, &buffer, sizeof buffer);
+    if (bytes_read > 0)
+      send_output(out, buffer, bytes_read);
+  }
+  return NULL;
+}
+static const char* redirect_fd(int fd, const OutputType out) {
+  static char error_buffer[256];
+  int new_fd[2];
+#ifdef PLATFORM_WINDOWS
+  if (_pipe(new_fd, 4096, O_TEXT) == -1) {
+#else
+  if (pipe(new_fd) == -1) {
+#endif
+    snprintf(error_buffer, sizeof error_buffer, "Couldn't create new pipe for fd %d. %s", fd, current_error());
+    return error_buffer;
+  }
+  if (dup2(new_fd[1], fd) == -1) {
+    snprintf(error_buffer, sizeof error_buffer, "Couldn't override the fd %d. %s", fd, current_error());
+    return error_buffer;
+  }
+
+  // args must be heap-allocated, otherwise they can go out-of-scope before the created thread reads them.
+  int* args = malloc(2 * sizeof *args);
+  args[0] = new_fd[0];
+  args[1] = out;
+  pthread_t thread;
+  if (pthread_create(&thread, NULL, &redirect_output_loop, args)) {
+    snprintf(error_buffer, sizeof error_buffer, "Couldn't create the redirect thread for fd %d. %s", fd, current_error());
+    return error_buffer;
+  }
+  return NULL;
+}
+
+static void redirect_output(FILE* file, const OutputType out) {
+  const char* error = redirect_fd(fileno(file), out);
+  if (error) {
+    log_printf("%s\n", error);
+    send_output(STDERR, error, strlen(error));
+  }
+}
+
+static inline void launch_target_in_terminal(const char* comm_file, const int argc, char* const argv[]) {
+  fprintf(stderr, "launch_target_in_terminal is not implemented\n");
+  exit(EXIT_FAILURE);
+}
+
+typedef struct DOUBLY_LINKED {
+  struct DOUBLY_LINKED* next;
+  struct DOUBLY_LINKED* prev;
+} DoublyLinked;
+
+typedef struct DELAYED_REQUEST {
+  DoublyLinked link;
+  const char* command;  // Not owned by Request
+  uint64_t request_seq;
+  void (*handle) (struct DELAYED_REQUEST* req);
+} DelayedRequest;
+
+static const char* canonicalize_request_name(const char* name);
+static void* DelayedRequest_create(const JSObject* request, size_t size, void (*handle)(DelayedRequest*)) {
+  DelayedRequest* req = malloc(size);
+  req->command = canonicalize_request_name(JSObject_get_string_field(request, "command"));
+  req->request_seq = JSObject_get_integer_field(request, "seq", 0);
+  req->handle = handle;
+  return req;
+}
+
+static DoublyLinked request_queue = {&request_queue, &request_queue};
+static pthread_mutex_t request_queue_lock;
+static inline bool request_queue_not_empty(void) {
+  return request_queue.next != &request_queue;
+}
+static inline void insert_to_request_queue(DelayedRequest* req) {
+  if (run_mode != RUN_MODE_TERMINATED) {
+    pthread_mutex_lock(&request_queue_lock);
+
+    DoublyLinked* it = &req->link;
+    DoublyLinked* prev = request_queue.prev;
+    request_queue.prev = it; it->prev = prev;
+    prev->next = it; it->next = &request_queue;
+
+    pthread_mutex_unlock(&request_queue_lock);
+  }
+}
+static inline DelayedRequest* remove_from_request_queue(void) {
+  assert(request_queue_not_empty());
+  pthread_mutex_lock(&request_queue_lock);
+
+  DoublyLinked* it = request_queue.next;
+  DoublyLinked* next = it->next;
+  request_queue.next = next;
+  next->prev = &request_queue;
+
+  pthread_mutex_unlock(&request_queue_lock);
+  return (DelayedRequest*) it;
+}
+
+// TODO: call handle_pending_debug_requests() from Stanza debugger
+static void handle_pending_debug_requests(void) {
+  while (request_queue_not_empty()) {
+    DelayedRequest* req = remove_from_request_queue();
+    req->handle(req);
+    free(req);
+  }
+}
+
+static inline unsigned request_queue_length(void) {
+  int count = 0;
+  for (const DoublyLinked* it = request_queue.next; it != &request_queue; it = it->next)
+    ++count;
+  return count;
+}
+// This function is not thread-safe. It is only intended for debuggung.
+static void print_request_queue(void) {
+  log_printf("Request queue (length: %u):\n", request_queue_length());
+  for (const DoublyLinked* it = request_queue.next; it != &request_queue; it = it->next) {
+    const DelayedRequest* req = (const DelayedRequest*) it;
+    log_printf("  %s\n", req->command);
+  }
+}
+
+static void JSBuilder_initialize_response_to_command(JSBuilder* builder, const char* command, uint64_t request_seq, const char* message) {
+  JSBuilder_initialize(builder);
+  JSBuilder_object_begin(builder);
+  JSBuilder_write_seq_0(builder);
+  JSBuilder_write_raw_string_field(builder, "type", "response");
+  JSBuilder_write_raw_string_field(builder, "command", command);
+  JSBuilder_write_unsigned_field(builder, "request_seq", request_seq);
+  JSBuilder_write_bool_field(builder, "success", message == NULL);
+  JSBuilder_write_optional_string_field(builder, "message", message);
+}
+static void JSBuilder_initialize_response(JSBuilder* builder, const JSObject* request, const char* message) {
+  const char* command = JSObject_get_string_field(request, "command");
+  const uint64_t request_seq = JSObject_get_integer_field(request, "seq", 0);
+  JSBuilder_initialize_response_to_command(builder, command, request_seq, message);
+}
+static void JSBuilder_initialize_delayed_response(JSBuilder* builder, const DelayedRequest* request, const char* message) {
+  JSBuilder_initialize_response_to_command(builder, request->command, request->request_seq, message);
+}
+static inline void JSBuilder_send_and_destroy_response(JSBuilder* builder) {
+  JSBuilder_send_and_destroy_object(builder);
+}
+static void respond_to_request(const JSObject* request, const char* message) {
+  JSBuilder builder;
+  JSBuilder_initialize_response(&builder, request, message);
+  JSBuilder_send_and_destroy_response(&builder);
+}
+static void respond_to_delayed_request(const DelayedRequest* request, const char* message) {
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, request, message);
+  JSBuilder_send_and_destroy_response(&builder);
+}
+
+// "InitializeRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Initialize request; value of command field is
+//                     'initialize'.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "initialize" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/InitializeRequestArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments" ]
+//   }]
+// },
+// "InitializeRequestArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'initialize' request.",
+//   "properties": {
+//     "clientID": {
+//       "type": "string",
+//       "description": "The ID of the (frontend) client using this adapter."
+//     },
+//     "adapterID": {
+//       "type": "string",
+//       "description": "The ID of the debug adapter."
+//     },
+//     "locale": {
+//       "type": "string",
+//       "description": "The ISO-639 locale of the (frontend) client using
+//                       this adapter, e.g. en-US or de-CH."
+//     },
+//     "linesStartAt1": {
+//       "type": "boolean",
+//       "description": "If true all line numbers are 1-based (default)."
+//     },
+//     "columnsStartAt1": {
+//       "type": "boolean",
+//       "description": "If true all column numbers are 1-based (default)."
+//     },
+//     "pathFormat": {
+//       "type": "string",
+//       "_enum": [ "path", "uri" ],
+//       "description": "Determines in what format paths are specified. The
+//                       default is 'path', which is the native format."
+//     },
+//     "supportsVariableType": {
+//       "type": "boolean",
+//       "description": "Client supports the optional type attribute for
+//                       variables."
+//     },
+//     "supportsVariablePaging": {
+//       "type": "boolean",
+//       "description": "Client supports the paging of variables."
+//     },
+//     "supportsRunInTerminalRequest": {
+//       "type": "boolean",
+//       "description": "Client supports the runInTerminal request."
+//     }
+//   },
+//   "required": [ "adapterID" ]
+// },
+// "InitializeResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'initialize' request.",
+//     "properties": {
+//       "body": {
+//         "$ref": "#/definitions/Capabilities",
+//         "description": "The capabilities of this debug adapter."
+//       }
+//     }
+//   }]
+// }
+static inline void define_capabilities(JSBuilder* builder) {
+  typedef struct { const char* name; bool value; } capability;
+  static const capability capabilities[] = {
+    {"supportsConfigurationDoneRequest", false},
+    {"supportsFunctionBreakpoints", false},
+    {"supportsConditionalBreakpoints", false},
+    // TODO: Supports breakpoints that break execution after a specified number of hits.
+    {"supportsHitConditionalBreakpoints", false},
+    // TODO: Supports a (side effect free) evaluate request for data hovers.
+    {"supportsEvaluateForHovers", false},
+    // TODO: Supports launching a debugee in intergrated VSCode terminal.
+    {"supportsRunInTerminalRequest", false},
+    // TODO: Supports stepping back via the stepBack and reverseContinue requests.
+    {"supportsStepBack", false},
+    // TODO: The debug adapter supports setting a variable to a value.
+    {"supportsSetVariable", false},
+    {"supportsRestartFrame", false},
+    {"supportsGotoTargetsRequest", false},
+    {"supportsStepInTargetsRequest", false},
+    // See the note on inherent inefficiency of completions in LLDB implementation.
+    {"supportsCompletionsRequest", false},
+    {"supportsModulesRequest", false},
+    // The set of additional module information exposed by the debug adapter.
+    //   body.try_emplace("additionalModuleColumns"] = ColumnDescriptor
+    // Checksum algorithms supported by the debug adapter.
+    //   body.try_emplace("supportedChecksumAlgorithms"] = ChecksumAlgorithm
+    // The debugger does not support the RestartRequest. The client must implement
+    // 'restart' by terminating and relaunching the adapter.
+    {"supportsRestartRequest", false},
+    // TODO: support 'exceptionOptions' on the setExceptionBreakpoints request.
+    {"supportsExceptionOptions", false},
+    // TODO: Support a 'format' attribute on the stackTraceRequest, variablesRequest, and evaluateRequest.
+    {"supportsValueFormattingOptions", true},
+    // TODO: support the exceptionInfo request.
+    {"supportsExceptionInfoRequest", false},
+    // TODO: support the 'terminateDebuggee' attribute on the 'disconnect' request.
+    {"supportTerminateDebuggee", false},
+    // The debugger does not support the delayed loading of parts of the stack,
+    // which would require support for 'startFrame' and 'levels' arguments and the
+    // 'totalFrames' result of the 'StackTrace' request.
+    {"supportsDelayedStackTraceLoading", false},
+    // TODO: support the 'loadedSources' request.
+    {"supportsLoadedSourcesRequest", false},
+    // Do we need this?
+    {"supportsProgressReporting", false},
+    {NULL, false} // Convenient NULL termunation.
+  };
+  for (const capability* p = capabilities; p->name; p++)
+    JSBuilder_write_bool_field(builder, p->name, p->value);
+
+  #if 0
+    // TODO:
+    // Available filters or options for the setExceptionBreakpoints request.
+    llvm::json::Array filters;
+    for (const auto &exc_bp : g_vsc.exception_breakpoints) {
+      filters.emplace_back(CreateExceptionBreakpointFilter(exc_bp));
+    }
+    body.try_emplace("exceptionBreakpointFilters", std::move(filters));
+  #endif
+}
+static bool request_initialize(const JSObject* request) {
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  client_supports_invalidated_event = JSObject_get_bool_field(arguments, "supportsInvalidatedEvent", false);
+
+  // TODO: initialize debugger here.
+  JSBuilder builder;
+  JSBuilder_initialize_response(&builder, request, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    define_capabilities(&builder);
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+  return true;
+}
+
+// "LaunchRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Launch request; value of command field is 'launch'.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "launch" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/LaunchRequestArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "LaunchRequestArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'launch' request.",
+//   "properties": {
+//     "noDebug": {
+//       "type": "boolean",
+//       "description": "If noDebug is true the launch request should launch
+//                       the program without enabling debugging."
+//     }
+//   }
+// },
+// "LaunchResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'launch' request. This is just an
+//                     acknowledgement, so no body field is required."
+//   }]
+// }
+static const char* get_string_array(const JSObject* object, const char* name, int reserve_at_start, const char*** out) {
+  const JSField* field = JSObject_get_field(object, name, JS_ARRAY);
+  const int length = field ? field->value.u.a.length : 0;
+  const char** q = (const char**) malloc((length + reserve_at_start + 1) * sizeof(char*));
+  *out = q;
+  q += reserve_at_start;
+  if (length) {
+    for (const JSValue *p = field->value.u.a.data, *limit = p + length; p < limit; p++) {
+      if (p->kind != JS_STRING) {
+        static char message[64];
+        // TODO: Print detailed message here with the index and value. maybe try to convert the value to string first.
+        // It looks like we only need JS arrays of strings. JSParser can be modified to store a pointer to source representation in a field.
+        snprintf(message, sizeof message, "%s: array of strings expected", name);
+        return message;
+      }
+      *q++ = p->u.s;
+    }
+  }
+  *q = NULL;
+  return NULL;
+}
+
+static inline void* untag(uint64_t x) {
+  assert((x & 7) == 1);
+  return (void*)(x - 1 + sizeof(void*));
+}
+
+typedef const struct STACK {
+  uint64_t size;            // long
+  uint64_t frames;          // ptr<StackFrame>
+  uint64_t stack_pointer;   // ptr<StackFrame>
+  uint64_t pc;              // long
+  const struct STACK* tail; // ptr<Stack>
+} Stack;
+
+typedef const struct {
+  uint64_t id;              // long
+  uint64_t stack;           // ref<Stack>
+  uint64_t parent;          // ref<False|RawCoroutine>
+  uint64_t status;          // ref<Int>
+  uint32_t num_winders;     // int
+  uint64_t crsp;            // long
+  uint64_t saved_winders;   // ref<SavedWinders>
+} RawCoroutine;
+
+// app_coroutine_refs[0] = &current_coroutine:ref<RawCoroutine>
+// app_coroutine_refs[1] = &stepping_coroutine:ref<False|RawCoroutine>
+uint64_t** app_coroutine_refs;
+static inline bool is_coroutine_closed(RawCoroutine* coroutine) {
+  return (coroutine->status >> 32) == 1;
+}
+
+extern uint64_t get_signal_handler_sp(void);
+extern uint64_t get_signal_handler_ip(void);
+static inline uint64_t current_stack_depth(RawCoroutine* current_coroutine) {
+  uint64_t sp = get_signal_handler_sp();
+  if (sp) {
+    Stack* stack = untag(current_coroutine->stack);
+    sp -= stack->frames;
+  }
+  return sp;
+}
+
+static inline SafepointEntry* current_safepoint_position(void) {
+  const uint64_t pc = get_signal_handler_ip();
+  if (pc) {
+    // This implementation is O(number-of-safepoints) and so would not scale for large apps.
+    // Building a hashtable at each debugger start would be slow.
+    // Consider building a hashtable at app compile time.
+    SafepointTable* safepoints = app_safepoint_table;
+    if (safepoints) {
+      for (uint64_t i = 0, num_files = app_safepoint_table->num_files; i < num_files; i++) {
+        FileSafepoints* file = safepoints->files[i];
+        for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
+          if (SafepointEntry_find(entry, (const void*)pc)) return entry;
+      }
+    }
+  }
+  // Construct a dummy safepoint entry for a rare case of missing safepoint when stopped at entry.
+  // This is only necessary to avoid null check prior to SafepointEntry_find.
+  static AddressList dummy_address_list = {0};
+  static SafepointEntry dummy_safepoint_entry = {0, &dummy_address_list};
+  return &dummy_safepoint_entry;
+}
+
+enum { false_ref = 2 };
+static uint64_t stepping_stack_depth;
+static SafepointEntry* stepping_position;
+
+static void remember_stepping_context(void) {
+  uint64_t* current_coroutine_ref_ptr = app_coroutine_refs[0];
+  uint64_t* stepping_coroutine_ref_ptr = app_coroutine_refs[1];
+  if (current_coroutine_ref_ptr) {
+    uint64_t current_coroutine_ref = *current_coroutine_ref_ptr;
+    *stepping_coroutine_ref_ptr = current_coroutine_ref;
+    RawCoroutine* current_coroutine = untag(current_coroutine_ref);
+    stepping_stack_depth = current_stack_depth(current_coroutine);
+    stepping_position = current_safepoint_position();
+  }
+}
+
+int stanza_main(int argc, char** argv);
+
+static void next_debug_event(void) {
+  do {
+    sleep(1);
+    handle_pending_debug_requests();
+  } while (run_mode == RUN_MODE_PAUSED);
+}
+
+void notify_stopped_at_entry(void) {
+  send_thread_stopped(STOP_REASON_ENTRY, "Stopped at entry", 0);
+  next_debug_event();
+}
+
+void notify_stopped_at_safepoint(const void* pc) {
+  // print_safepoint(pc);
+  char description[64];
+  const uint64_t breakpoint = (uint64_t) ActiveFileSafepoints_find_entry(pc);
+  uint64_t* current_coroutine_ref_ptr = app_coroutine_refs[0];
+  uint64_t* stepping_coroutine_ref_ptr = app_coroutine_refs[1];
+  StopReason reason = run_mode == RUN_MODE_RUNNING ? STOP_REASON_PAUSE : STOP_REASON_STEP;
+  if (breakpoint) {
+    snprintf(description, sizeof description, "breakpoint %" PRIu64, breakpoint);
+    reason = STOP_REASON_BREAKPOINT;
+  } else if (run_mode >= RUN_MODE_STEP_OUT && stepping_coroutine_ref_ptr && *stepping_coroutine_ref_ptr != false_ref) {
+    uint64_t stepping_coroutine_ref = *stepping_coroutine_ref_ptr;
+    RawCoroutine* stepping_coroutine = untag(stepping_coroutine_ref);
+    if (!is_coroutine_closed(stepping_coroutine)) {
+      // If we are in different coroutine, continue stepping.
+      if (stepping_coroutine_ref != *current_coroutine_ref_ptr) return;
+
+      uint64_t stack_depth = current_stack_depth(stepping_coroutine);
+      if (stack_depth >= stepping_stack_depth) {
+        if (stack_depth > stepping_stack_depth) return;
+        if (run_mode == RUN_MODE_STEP_OUT) return;
+        if (SafepointEntry_find(stepping_position, pc)) return;
+      }
+    }
+  }
+
+  // Forget stepping coroutine
+  if (stepping_coroutine_ref_ptr)
+    *stepping_coroutine_ref_ptr = false_ref;
+
+  send_thread_stopped(reason, description, breakpoint);
+  next_debug_event();
+}
+
+// Skeleton of Stanza debgger. It runs on a separate thread.
+// TODO: replace it woth LoStanza function.
+static void* handle_launch(void* args) {
+  char** argv = (char**) args;
+  // TODO: Replace the code below with the debugger run with 'argv'
+  log_printf("! Running stanza program %s with arguments:\n", argv[0]);
+  for (char** p = argv; *++p;)
+    log_printf("  %s\n", *p);
+
+  int argc = 0;
+  for (char** p = argv; *p++; argc++);
+  stanza_main(argc, argv);
+
+  send_process_exited(0);
+  return NULL;
+}
+
+static inline const char* launch_program(const JSObject* request_arguments) {
+  const char* cwd = JSObject_get_string_field(request_arguments, "cwd");
+  if (cwd && chdir(cwd)) return current_error();
+
+  const bool stop_at_entry = JSObject_get_bool_field(request_arguments, "stopOnEntry", false);
+  // O.P.: Do we need this?
+  // const bool runInTerminal = JSObject_get_boolean_field(request_arguments, "runInTerminal", false);
+
+  const char* program = JSObject_get_string_field(request_arguments, "program");
+  if (!program) return "no program specified";
+
+  const char** args = NULL;
+  const char* error = get_string_array(request_arguments, "args", 2, &args);
+  if (!error) {
+    const char** env = NULL;
+    error = get_string_array(request_arguments, "env", 0, &env);
+    if (!error) {
+      free_path(program_path);
+      program_path = get_absolute_path(program);
+      args[1] = program_path;
+      args[0] = debug_adapter_path;
+      // TODO: launch the program here, remember program_pid
+      // For now, lets just run stanza debugger in-process on a separate thread and ignore 'env'
+      pthread_t program_thread;
+      if (pthread_create(&program_thread, NULL, &handle_launch, args)) {
+        static char error_buffer[256];
+        snprintf(error_buffer, sizeof error_buffer, "Couldn't create stanza program thread. %s", current_error());
+        error = error_buffer;
+      }
+      program_pid = getpid();
+    }
+    free(env);
+  }
+  // Yes, 'args' leaks memory as it can be used by program_thread. Please uncomment the line below when a program launched as a process.
+  // free(args);
+  return error;
+}
+static bool request_launch(const JSObject* request) {
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  //TODO: Do we really need built-in debugger commands interpreter?
+  // init_commands = GetStrings(arguments, "initCommands");
+  // pre_run_commands = GetStrings(arguments, "preRunCommands");
+  // stop_commands = GetStrings(arguments, "stopCommands");
+  // exit_commands = GetStrings(arguments, "exitCommands");
+  // terminate_commands = GetStrings(arguments, "terminateCommands");
+  // auto launchCommands = GetStrings(arguments, "launchCommands");
+  // std::vector<std::string> postRunCommands = GetStrings(arguments, "postRunCommands");
+
+  // TODO: Do we really need debuggerRoot?
+  // const char* debugger_root = JSObject_get_string_field(arguments, "debuggerRoot");
+  // const uint64_t timeout_seconds = JSObject_get_integer_field(arguments, "timeout", 30);
+
+  // This is a hack for loading DWARF in .o files on Mac where the .o files
+  // in the debug map of the main executable have relative paths which require
+  // the lldb-vscode binary to have its working directory set to that relative
+  // root for the .o files in order to be able to load debug info.
+  // if (!debuggerRoot.empty())
+  //  llvm::sys::fs::set_current_path(debuggerRoot);
+
+  // Run any initialize LLDB commands the user specified in the launch.json.
+  // This is run before target is created, so commands can't do anything with
+  // the targets - preRunCommands are run with the target.
+  // RunInitCommands();
+
+  //TODO: Do we really need sourcePath or sourceMap?
+  // LLDB supports only sourceMap and ignores sourcePath.
+  // SetSourceMapFromArguments(*arguments);
+  const char* error = launch_program(arguments);
+  respond_to_request(request, error);
+  if (error)
+    log_printf("launch_request error: %s\n", error);
+  else
+    send_process_launched();
+  send_simple_event("initialized");
+  return true;
+}
+
+// VSCode issues separate setBreakpoints request for each source file
+// where some breakpoints are currently set or were set before.
+// The request lists all breakpoints in this file.
+// The debugger has to sync its breakpoints for this file with breakpoints in this list.
+//
+// "SetBreakpointsRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "SetBreakpoints request; value of command field is
+//     'setBreakpoints'. Sets multiple breakpoints for a single source and
+//     clears all previous breakpoints in that source. To clear all breakpoint
+//     for a source, specify an empty array. When a breakpoint is hit, a
+//     StoppedEvent (event type 'breakpoint') is generated.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "setBreakpoints" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/SetBreakpointsArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "SetBreakpointsArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'setBreakpoints' request.",
+//   "properties": {
+//     "source": {
+//       "$ref": "#/definitions/Source",
+//       "description": "The source location of the breakpoints; either
+//       source.path or source.reference must be specified."
+//     },
+//     "breakpoints": {
+//       "type": "array",
+//       "items": {
+//         "$ref": "#/definitions/SourceBreakpoint"
+//       },
+//       "description": "The code locations of the breakpoints."
+//     },
+//     "lines": {
+//       "type": "array",
+//       "items": {
+//         "type": "integer"
+//       },
+//       "description": "Deprecated: The code locations of the breakpoints."
+//     },
+//     "sourceModified": {
+//       "type": "boolean",
+//       "description": "A value of true indicates that the underlying source
+//       has been modified which results in new breakpoint locations."
+//     }
+//   },
+//   "required": [ "source" ]
+// },
+// "SetBreakpointsResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'setBreakpoints' request. Returned is
+//     information about each breakpoint created by this request. This includes
+//     the actual code location and whether the breakpoint could be verified.
+//     The breakpoints returned are in the same order as the elements of the
+//     'breakpoints' (or the deprecated 'lines') in the
+//     SetBreakpointsArguments.", "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "breakpoints": {
+//             "type": "array",
+//             "items": {
+//               "$ref": "#/definitions/Breakpoint"
+//             },
+//             "description": "Information about the breakpoints. The array
+//             elements are in the same order as the elements of the
+//             'breakpoints' (or the deprecated 'lines') in the
+//             SetBreakpointsArguments."
+//           }
+//         },
+//         "required": [ "breakpoints" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// },
+// "SourceBreakpoint": {
+//   "type": "object",
+//   "description": "Properties of a breakpoint or logpoint passed to the
+//   setBreakpoints request.", "properties": {
+//     "line": {
+//       "type": "integer",
+//       "description": "The source line of the breakpoint or logpoint."
+//     },
+//     "column": {
+//       "type": "integer",
+//       "description": "An optional source column of the breakpoint."
+//     },
+//     "condition": {
+//       "type": "string",
+//       "description": "An optional expression for conditional breakpoints."
+//     },
+//     "hitCondition": {
+//       "type": "string",
+//       "description": "An optional expression that controls how many hits of
+//       the breakpoint are ignored. The backend is expected to interpret the
+//       expression as needed."
+//     },
+//     "logMessage": {
+//       "type": "string",
+//       "description": "If this attribute exists and is non-empty, the backend
+//       must not 'break' (stop) but log the message instead. Expressions within
+//       {} are interpolated."
+//     }
+//   },
+//   "required": [ "line" ]
+// }
+
+static bool request_setBreakpoints(const JSObject* request) {
+  JSBuilder builder;
+  JSBuilder_initialize_response(&builder, request, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    JSBuilder_array_field_begin(&builder, "breakpoints");
+    {
+      const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+      const JSObject* source = JSObject_get_object_field(arguments, "source");
+      const char* path = JSObject_get_string_field(source, "path");
+      FileSafepoints* safepoints = Safepoints_find_file(path);
+      // We cannot just send empty set of breakpoints if there is no safepoints in given file.
+      // If a requested breakpoint cannot be set, it must be reported as unreachable.
+      if (safepoints) {
+        pthread_mutex_lock(&safepoint_lock);
+        ActiveFileSafepoints_destroy(safepoints);
+        FileSafepoints_write(safepoints, NOP);  // Clear all safeponts in the file
+      }
+      const JSArray* breakpoints = JSObject_get_array_field(arguments, "breakpoints");
+      if (breakpoints) {
+        SafepointEntryVector v;
+        SafepointEntryVector_initialize(&v);
+        for (const JSValue *p = breakpoints->data, *const limit = p + breakpoints->length; p < limit; p++) {
+          if (p->kind == JS_OBJECT) {
+            const JSObject* o = &p->u.o;
+            uint64_t line = JSObject_get_integer_field(o, "line", 0);
+            // const int64_t column = JSObject_get_integer_field(o, "column", 0);
+            // TODO: get optional condition, hitCondition and logMessage fields.
+            SafepointEntry* entry = FileSafepoints_find(safepoints, line);
+            if (entry) {
+              line = entry->line;
+              if (!SafepointEntryVector_find(&v, entry)) {
+                *SafepointEntryVector_allocate(&v) = entry;
+                if (!all_sefapoints_enabled)
+                  SafepointEntry_write(entry, INT3);
+              }
+            }
+            JSBuilder_next(&builder);
+            JSBuilder_write_breakpoint(&builder, (uint64_t)entry, entry != NULL, path, line, 0);
+          }
+        }
+        ActiveFileSafepoints_create(safepoints, &v);
+        SafepointEntryVector_destroy(&v);
+      }
+      if (safepoints)
+        pthread_mutex_unlock(&safepoint_lock);
+    }
+    JSBuilder_array_field_end(&builder); // breakpoints
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+  return true;
+}
+
+// "SetExceptionBreakpointsRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "SetExceptionBreakpoints request; value of command field
+//     is 'setExceptionBreakpoints'. The request configures the debuggers
+//     response to thrown exceptions. If an exception is configured to break, a
+//     StoppedEvent is fired (event type 'exception').", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "setExceptionBreakpoints" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/SetExceptionBreakpointsArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "SetExceptionBreakpointsArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'setExceptionBreakpoints' request.",
+//   "properties": {
+//     "filters": {
+//       "type": "array",
+//       "items": {
+//         "type": "string"
+//       },
+//       "description": "IDs of checked exception options. The set of IDs is
+//       returned via the 'exceptionBreakpointFilters' capability."
+//     },
+//     "exceptionOptions": {
+//       "type": "array",
+//       "items": {
+//         "$ref": "#/definitions/ExceptionOptions"
+//       },
+//       "description": "Configuration options for selected exceptions."
+//     }
+//   },
+//   "required": [ "filters" ]
+// },
+// "SetExceptionBreakpointsResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'setExceptionBreakpoints' request. This is
+//     just an acknowledgement, so no body field is required."
+//   }]
+// }
+static bool request_setExceptionBreakpoints(const JSObject* request) {
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  const JSArray* filters = JSObject_get_array_field(arguments, "filters");
+  // TODO: Cleanup all exception breakpoints in the debugger here.
+  // TODO: Set each exception breakpoint in the debugger:
+  // for (const JSValue *p = filters->data, *const limit = p + filters->length; p < limit; p++)
+  //  if (p->kind == JS_STRING)
+  //    TODO: set exception breakpoint in the debugger with p->u.s filter.
+
+  respond_to_request(request, NULL);
+  return true;
+}
+
+// "SourceRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Source request; value of command field is 'source'. The
+//     request retrieves the source code for a given source reference.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "source" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/SourceArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "SourceArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'source' request.",
+//   "properties": {
+//     "source": {
+//       "$ref": "#/definitions/Source",
+//       "description": "Specifies the source content to load. Either
+//       source.path or source.sourceReference must be specified."
+//     },
+//     "sourceReference": {
+//       "type": "integer",
+//       "description": "The reference to the source. This is the same as
+//       source.sourceReference. This is provided for backward compatibility
+//       since old backends do not understand the 'source' attribute."
+//     }
+//   },
+//   "required": [ "sourceReference" ]
+// },
+// "SourceResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'source' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "content": {
+//             "type": "string",
+//             "description": "Content of the source reference."
+//           },
+//           "mimeType": {
+//             "type": "string",
+//             "description": "Optional content type (mime type) of the source."
+//           }
+//         },
+//         "required": [ "content" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+static bool request_source(const JSObject* request) {
+  respond_to_request(request, "Source file not found");
+  return true;
+}
+
+// "ThreadsRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Thread request; value of command field is 'threads'. The
+//     request retrieves a list of all threads.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "threads" ]
+//       }
+//     },
+//     "required": [ "command" ]
+//   }]
+// },
+// "ThreadsResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'threads' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "threads": {
+//             "type": "array",
+//             "items": {
+//               "$ref": "#/definitions/Thread"
+//             },
+//             "description": "All threads."
+//           }
+//         },
+//         "required": [ "threads" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+static inline void Environment_reset(void);
+typedef DelayedRequest DelayedRequestThreads;
+static void DelayedRequestThreads_handle(DelayedRequest* req) {
+  Environment_reset();
+
+  JSBuilder builder;
+  // TODO: If no active stack exists, pass an error message instead of NULL here.
+  JSBuilder_initialize_delayed_response(&builder, req, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    // TODO: Should we list coroutines here?
+    JSBuilder_array_field_begin(&builder, "threads");
+    {
+      JSBuilder_next(&builder);
+      JSBuilder_object_begin(&builder); // an individual thread
+      {
+        JSBuilder_write_unsigned_field(&builder, "id", thread_id);
+        JSBuilder_write_raw_string_field(&builder, "name", "main");
+      }
+      JSBuilder_object_end(&builder); // an individual thread
+    }
+    JSBuilder_array_field_end(&builder);
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+}
+static inline DelayedRequest* DelayedRequestThreads_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestThreads), &DelayedRequestThreads_handle);
+}
+static bool request_threads(const JSObject* request) {
+  insert_to_request_queue(DelayedRequestThreads_create(request));
+  return true;
+}
+
+// "StackTraceRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "StackTrace request; value of command field is
+//     'stackTrace'. The request returns a stacktrace from the current execution
+//     state.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "stackTrace" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/StackTraceArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "StackTraceArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'stackTrace' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Retrieve the stacktrace for this thread."
+//     },
+//     "startFrame": {
+//       "type": "integer",
+//       "description": "The index of the first frame to return; if omitted
+//       frames start at 0."
+//     },
+//     "levels": {
+//       "type": "integer",
+//       "description": "The maximum number of frames to return. If levels is
+//       not specified or 0, all frames are returned."
+//     },
+//     "format": {
+//       "$ref": "#/definitions/StackFrameFormat",
+//       "description": "Specifies details on how to format the stack frames."
+//     }
+//  },
+//   "required": [ "threadId" ]
+// },
+// "StackTraceResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'stackTrace' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "stackFrames": {
+//             "type": "array",
+//             "items": {
+//               "$ref": "#/definitions/StackFrame"
+//             },
+//             "description": "The frames of the stackframe. If the array has
+//             length zero, there are no stackframes available. This means that
+//             there is no location information available."
+//           },
+//           "totalFrames": {
+//             "type": "integer",
+//             "description": "The total number of frames available."
+//           }
+//         },
+//         "required": [ "stackFrames" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+#define DEFINE_STACK_FRAME_FORMAT(def)\
+  def(0, hex)            \
+  def(1, parameters)     \
+  def(2, parameterTypes) \
+  def(3, parameterNames) \
+  def(4, parameterValues)\
+  def(5, line)           \
+  def(6, module)         \
+  def(7, includeAll)
+enum {
+  #define DEFINE_STACK_FRAME_FORMAT_MASK(number, name) STACK_FRAME_FORMAT_##name = 1 << number,
+  DEFINE_STACK_FRAME_FORMAT(DEFINE_STACK_FRAME_FORMAT_MASK)
+  #undef DEFINE_STACK_FRAME_FORMAT_MASK
+};
+static inline uint64_t parse_stack_frame_format(const JSObject* format) {
+  static const char* const names[] = {
+    #define DEFINE_STACK_FRAME_FORMAT_NAME(number, name) #name,
+    DEFINE_STACK_FRAME_FORMAT(DEFINE_STACK_FRAME_FORMAT_NAME)
+    #undef DEFINE_STACK_FRAME_FORMAT_NAME
+    NULL
+  };
+
+  uint64_t x = 0;
+  uint64_t mask = 1;
+  for (const char* const* name = names; *name; name++, mask <<= 1)
+    if (JSObject_get_bool_field(format, *name, false))
+      x |= mask;
+  return x;
+}
+typedef struct {
+  char* function_name;  // Owned by StackTraceFrame
+  char* source_path;    // Owned by StackTraceFrame
+  int64_t line;         // 1-based
+  int64_t column;       // 1-based, 0 denotes unknown
+  uint64_t pc;
+  uint64_t sp;
+  size_t scopes;        // Index in current environment, or 0 when unknown
+} StackTraceFrame;
+typedef struct {
+  size_t length;
+  size_t capacity;
+  StackTraceFrame* data;
+  uint64_t format;
+} StackTrace;
+static inline void StackTrace_initialize(StackTrace* st) {
+  st->length = 0;
+  st->capacity = 16; // Initial stack trace size
+  st->data = malloc(st->capacity * sizeof(StackTraceFrame));
+  //TODO: handle possible OOME
+}
+static inline void StackTrace_destroy(StackTrace* st) {
+  for (const StackTraceFrame *p = st->data, *const limit = p + st->length; p < limit; p++) {
+    free(p->function_name);
+    free(p->source_path);
+  }
+  free(st->data);
+}
+static inline void StackTrace_reset(StackTrace* st) {
+  StackTrace_destroy(st);
+  StackTrace_initialize(st);
+}
+static inline StackTraceFrame* StackTrace_allocate(StackTrace* st) {
+  if (st->length == st->capacity) {
+    st->capacity <<= 1;
+    st->data = realloc(st->data, st->capacity * sizeof(StackTraceFrame));
+    //TODO: handle possible OOM
+  }
+  return st->data + st->length++;
+}
+static StackTrace current_stack_trace;
+
+// Variable attributes (must be known to the debugger)
+enum {
+  VARIABLE_PUBLIC = 1,
+  VARIABLE_PRIVATE = 2,
+  VARIABLE_PROTECTED = 3,
+  VARIABLE_VISIBILITY_MASK = 3,
+  VARIABLE_CONSTANT = 1 << 2,
+  VARIABLE_KIND_LOCALS = 1 << 3,
+  VARIABLE_KIND_GLOBALS = 2 << 3,
+  VARIABLE_KIND_MASK = 3 << 3
+};
+static inline const char* variable_visibility(const unsigned variable_attributes) {
+  static const char* const names[] = {
+    NULL,
+    "public",
+    "private",
+    "protected"
+  };
+  return names[variable_attributes & VARIABLE_VISIBILITY_MASK];
+}
+
+typedef struct {
+  char* name;           // Owned by Variable
+  char* type;           // Owned by Variable
+  char* value;          // Owned by Variable
+  const void* ref;
+  size_t fields_count;
+  size_t fields_base;
+  uint8_t attributes;
+} Variable;
+static inline Variable* Variable_initialize(Variable* var, const void* ref, const char* name, size_t fields_count, uint8_t attributes) {
+  var->name = strdup(name);
+  var->type = NULL;
+  var->value = NULL;
+  var->ref = ref;
+  var->fields_count = fields_count;
+  var->fields_base = 0;
+  var->attributes = attributes;
+  return var;
+}
+static inline void Variable_destroy(const Variable* var) {
+  free(var->name);
+  free(var->type);
+  free(var->value);
+}
+static void JSBuilder_write_variable_fields_count(JSBuilder* builder, const Variable* var) {
+  JSBuilder_write_optional_unsigned_field(builder, "namedVariables", var->fields_count);
+}
+static inline void JSBuilder_write_variable(JSBuilder* builder, const Variable* var, const uint64_t var_id) {
+  JSBuilder_object_begin(builder);
+  {
+    // Variable with zero fields must have zero id.
+    JSBuilder_write_unsigned_field(builder, "variablesReference", var->fields_count ? var_id : 0);
+    JSBuilder_write_raw_string_field(builder, "name", var->name);
+    JSBuilder_write_optional_string_field(builder, "type", var->type);
+    JSBuilder_write_string_field(builder, "value", var->value);
+    JSBuilder_write_variable_fields_count(builder, var);
+
+    const unsigned attributes = var->attributes;
+    if (attributes) {
+      JSBuilder_object_field_begin(builder, "presentationHint");
+      {
+        if (attributes & VARIABLE_CONSTANT)
+          JSBuilder_write_raw_string_field(builder, "attributes", "constant");
+        JSBuilder_write_optional_raw_string_field(builder, "visibility", variable_visibility(attributes));
+      }
+      JSBuilder_object_field_end(builder);
+    }
+  }
+  JSBuilder_object_end(builder);
+}
+
+struct {
+  size_t length;
+  size_t capacity;
+  Variable* data;
+} current_env; // Belongs to the app thread
+
+static Variable* Environment_allocate(const void* ref, const char* name, size_t fields_count, uint8_t attributes) {
+  if (current_env.length == current_env.capacity) {
+    current_env.capacity <<= 1;
+    current_env.data = realloc(current_env.data, current_env.capacity * sizeof(Variable));
+    //TODO: handle possible OOM
+  }
+  return Variable_initialize(current_env.data + current_env.length++, ref, name, fields_count, attributes);
+}
+static inline Variable* Environment_get(uint64_t variable_id) {
+  assert(variable_id < current_env.length);
+  return current_env.data + variable_id;
+}
+static inline void Environment_initialize(void) {
+  current_env.length = 0;
+  current_env.capacity = 64;
+  current_env.data = malloc(current_env.capacity * sizeof(Variable));
+}
+static inline void Environment_destroy(void) {
+  // It is safe to destroy uninitialized Environment:
+  // by default all fields are zeroed
+  for (Variable *p = current_env.data, *limit = p + current_env.length; p < limit; p++)
+    Variable_destroy(p);
+  free(current_env.data);
+}
+static inline void Environment_reset(void) {
+  Environment_destroy();
+  Environment_initialize();
+  Environment_allocate(NULL, "Root scope", 2, 0);
+  StackTrace_reset(&current_stack_trace);
+}
+
+void append_stack_frame(uint64_t pc, uint64_t sp, const char* function_name,
+                        const char* source_path, int64_t line, int64_t column) {
+  StackTraceFrame* frame = StackTrace_allocate(&current_stack_trace);
+  frame->function_name = strdup(function_name);
+  frame->source_path = strdup(source_path);
+  frame->line = line;
+  frame->column = column;
+  frame->pc = pc;
+  frame->sp = sp;
+  frame->scopes = 0;
+}
+
+// Create stack trace for given thread_id starting at start level with no more than max_frames frames.
+// Frames not visible to the debugger can be skipped.
+// Returns total number of frames in thread_id stack or -1 when no thread with given thread_id thread_is found.
+void create_stack_trace(const uint64_t format) ;
+void need_stack_trace(void) {
+  if (run_mode != RUN_MODE_TERMINATED && stack_trace_available && !current_stack_trace.length)
+    create_stack_trace(current_stack_trace.format);
+}
+
+typedef struct {
+  DelayedRequest parent;
+  int64_t start_frame;
+  int64_t max_frames;
+  uint64_t format;
+} DelayedRequestStackTrace;
+static void DelayedRequestStackTrace_handle(DelayedRequest* request) {
+  const DelayedRequestStackTrace* req = (const DelayedRequestStackTrace*)request;
+  if (req->format != current_stack_trace.format) {
+    current_stack_trace.format = req->format;
+    StackTrace_reset(&current_stack_trace);
+  }
+  need_stack_trace();
+  const int64_t total_frames = current_stack_trace.length;
+
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, request, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  if (total_frames >= 0) {
+    JSBuilder_write_unsigned_field(&builder, "totalFrames", total_frames);
+    JSBuilder_array_field_begin(&builder, "stackFrames");
+    for (const StackTraceFrame *p = current_stack_trace.data, *const limit = p + total_frames; p < limit; p++) {
+      JSBuilder_next(&builder);
+      JSBuilder_object_begin(&builder);
+      {
+        JSBuilder_write_unsigned_field(&builder, "id", (uint64_t)p);
+        JSBuilder_write_string_field(&builder, "name", p->function_name);
+        if (p->source_path) {
+          JSBuilder_object_field_begin(&builder, "source");
+          {
+            JSBuilder_write_string_field(&builder, "path", p->source_path);
+          }
+          JSBuilder_object_field_end(&builder);
+        }
+        JSBuilder_write_unsigned_field(&builder, "line", p->line);
+        JSBuilder_write_unsigned_field(&builder, "column", p->column);  //Mandatory here
+      }
+      JSBuilder_object_end(&builder);
+    }
+    JSBuilder_array_field_end(&builder); // stackFrames
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+}
+static inline DelayedRequest* DelayedRequestStackTrace_create(const JSObject* request) {
+  DelayedRequestStackTrace* req = DelayedRequest_create(request, sizeof(DelayedRequestStackTrace), &DelayedRequestStackTrace_handle);
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // Stanza implementatin is single-threaded. Interpret thread_id as coroutine_id?
+  // req->thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  req->start_frame = JSObject_get_integer_field(arguments, "startFrame", 0);
+  req->max_frames = JSObject_get_integer_field(arguments, "levels", INT64_MAX);
+  req->format = parse_stack_frame_format(JSObject_get_object_field(arguments, "format"));
+  return (DelayedRequest*) req;
+}
+static bool request_stackTrace(const JSObject* request) {
+  insert_to_request_queue(DelayedRequestStackTrace_create(request));
+  return true;
+}
+
+// "ScopesRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Scopes request; value of command field is 'scopes'. The
+//     request returns the variable scopes for a given stackframe ID.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "scopes" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/ScopesArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "ScopesArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'scopes' request.",
+//   "properties": {
+//     "frameId": {
+//       "type": "integer",
+//       "description": "Retrieve the scopes for this stackframe."
+//     }
+//   },
+//   "required": [ "frameId" ]
+// },
+// "ScopesResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'scopes' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "scopes": {
+//             "type": "array",
+//             "items": {
+//               "$ref": "#/definitions/Scope"
+//             },
+//             "description": "The scopes of the stackframe. If the array has
+//             length zero, there are no scopes available."
+//           }
+//         },
+//         "required": [ "scopes" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+
+static void JSBuilder_write_scope(JSBuilder* builder, const uint64_t scope_id, const char* hint) {
+  JSBuilder_next(builder);
+  JSBuilder_object_begin(builder);
+  {
+    JSBuilder_write_unsigned_field(builder, "variablesReference", scope_id);
+    const Variable* var = Environment_get(scope_id);
+    JSBuilder_write_raw_string_field(builder, "name", var->name);
+    JSBuilder_write_variable_fields_count(builder, var);
+    JSBuilder_write_raw_string_field(builder, "presentationHint", hint);
+    JSBuilder_write_bool_field(builder, "expensive", false);
+  }
+  JSBuilder_object_end(builder);
+}
+
+uint32_t number_of_globals(void);
+uint32_t number_of_locals(uint64_t pc);
+
+static inline StackTraceFrame* validate_stack_trace_frame(StackTraceFrame* frame) {
+  if (frame) {
+    const uint64_t offset = (uint64_t)frame - (uint64_t)current_stack_trace.data;
+    if (offset % sizeof(StackTraceFrame) == 0) {
+      const uint64_t index = offset / sizeof(StackTraceFrame);
+      if (index < (uint64_t)current_stack_trace.length)
+        return frame;
+    }
+  }
+  return NULL;
+}
+
+typedef struct {
+  DelayedRequest parent;
+  StackTraceFrame* frame;
+} DelayedRequestScopes;
+static void DelayedRequestScopes_handle(DelayedRequest* request) {
+  need_stack_trace();
+
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, request, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    JSBuilder_array_field_begin(&builder, "scopes");
+    const DelayedRequestScopes* req = (const DelayedRequestScopes*)request;
+    StackTraceFrame* frame = validate_stack_trace_frame(req->frame);
+    if (frame) {
+      if (!frame->scopes) {
+        frame->scopes = current_env.length;
+        Environment_allocate(frame, "Locals", number_of_locals(frame->pc), VARIABLE_KIND_LOCALS);
+        Environment_allocate(frame, "Globals", number_of_globals(), VARIABLE_KIND_GLOBALS);
+      }
+      const uint64_t scopes = frame->scopes;
+      JSBuilder_write_scope(&builder, scopes + 0, "locals");
+      JSBuilder_write_scope(&builder, scopes + 1, "globals");
+    }
+    JSBuilder_array_field_end(&builder);
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+}
+
+static inline DelayedRequest* DelayedRequestScopes_create(const JSObject* request) {
+  DelayedRequestScopes* req = DelayedRequest_create(request, sizeof(DelayedRequestScopes), &DelayedRequestScopes_handle);
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  req->frame = (StackTraceFrame*)JSObject_get_integer_field(arguments, "frameId", INVALID_FRAME_ID);
+  return (DelayedRequest*) req;
+}
+static bool request_scopes(const JSObject* request) {
+  // O.P.: Following comment is shamelessly borrowed from LLDB:
+  // As the user selects different stack frames in the GUI, a "scopes" request
+  // will be sent to the DAP. This is the only way we know that the user has
+  // selected a frame in a thread. There are no other notifications that are
+  // sent and VS code doesn't allow multiple frames to show variables
+  // concurrently. If we select the thread and frame as the "scopes" requests
+  // are sent, this allows users to type commands in the debugger console
+  // with a backtick character to run lldb commands and these lldb commands
+  // will now have the right context selected as they are run. If the user
+  // types "`bt" into the debugger console and we had another thread selected
+  // in the LLDB library, we would show the wrong thing to the user. If the
+  // users switches threads with a lldb command like "`thread select 14", the
+  // GUI will not update as there are no "event" notification packets that
+  // allow us to change the currently selected thread or frame in the GUI that
+  // I am aware of.
+
+  insert_to_request_queue(DelayedRequestScopes_create(request));
+  return true;
+}
+
+// "VariablesRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Variables request; value of command field is 'variables'.
+//     Retrieves all child variables for the given variable reference. An
+//     optional filter can be used to limit the fetched children to either named
+//     or indexed children.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "variables" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/VariablesArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "VariablesArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'variables' request.",
+//   "properties": {
+//     "variablesReference": {
+//       "type": "integer",
+//       "description": "The Variable reference."
+//     },
+//     "filter": {
+//       "type": "string",
+//       "enum": [ "indexed", "named" ],
+//       "description": "Optional filter to limit the child variables to either
+//       named or indexed. If ommited, both types are fetched."
+//     },
+//     "start": {
+//       "type": "integer",
+//       "description": "The index of the first variable to return; if omitted
+//       children start at 0."
+//     },
+//     "count": {
+//       "type": "integer",
+//       "description": "The number of variables to return. If count is missing
+//       or 0, all variables are returned."
+//     },
+//     "format": {
+//       "$ref": "#/definitions/ValueFormat",
+//       "description": "Specifies details on how to format the Variable
+//       values."
+//     }
+//   },
+//   "required": [ "variablesReference" ]
+// },
+// "VariablesResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'variables' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "variables": {
+//             "type": "array",
+//             "items": {
+//               "$ref": "#/definitions/Variable"
+//             },
+//             "description": "All (or a range) of variables for the given
+//             variable reference."
+//           }
+//         },
+//         "required": [ "variables" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+void append_variable(const void* ref, const char* name, const char* type, const char* value,
+                     uint64_t fields_count, uint8_t attributes) {
+  Variable* v = Environment_allocate(ref, name, fields_count, attributes);
+  v->type = strdup(type);
+  v->value = strdup(value);
+  v->ref = ref;
+}
+void create_globals(uint64_t hex);
+void create_locals(uint64_t pc, uint64_t sp, uint64_t hex);
+void create_fields(const void* ref, const char* name, uint64_t hex);
+
+typedef struct {
+  DelayedRequest parent;
+  uint64_t variable_id;
+  bool hex;
+} DelayedRequestVariables;
+static void DelayedRequestVariables_handle(DelayedRequest* request) {
+  const DelayedRequestVariables* req = (const DelayedRequestVariables*)request;
+
+  const uint64_t variable_id = req->variable_id;
+  if (variable_id >= (uint64_t)current_env.length) {  // Sanity check for variable id
+    respond_to_delayed_request(request, "Invalid variable reference");
+    return;
+  }
+
+  Variable* var = current_env.data + variable_id;
+  size_t fields_base = var->fields_base;
+  const uint64_t fields_count = var->fields_count;
+  if (fields_count && !fields_base) {
+    fields_base = current_env.length;
+    var->fields_base = fields_base;
+    const uint64_t hex = req->hex;
+    switch (var->attributes & VARIABLE_KIND_MASK) {
+      default:
+        create_fields(var->ref, var->name, hex);
+        break;
+      case VARIABLE_KIND_GLOBALS:
+        create_globals(hex);
+        break;
+      case VARIABLE_KIND_LOCALS:
+        const StackTraceFrame* frame = var->ref;
+        create_locals(frame->pc, frame->sp, hex);
+        break;
+    }
+    var = NULL; // Nuke 'var' as it could become invalid when 'current_env.data' expands.
+  }
+
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, request, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    JSBuilder_array_field_begin(&builder, "variables");
+    const Variable* data = current_env.data;
+    for (uint64_t i = fields_base, limit = i + fields_count; i < limit; i++) {
+      JSBuilder_next(&builder);
+      JSBuilder_write_variable(&builder, data + i, i);
+    }
+    JSBuilder_array_field_end(&builder);
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+}
+static inline DelayedRequest* DelayedRequestVariables_create(const JSObject* request) {
+  DelayedRequestVariables* req = DelayedRequest_create(request, sizeof(DelayedRequestVariables), &DelayedRequestVariables_handle);
+  const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  req->variable_id = JSObject_get_integer_field(arguments, "variablesReference", -1);
+  const JSObject* format = JSObject_get_object_field(arguments, "format");
+  req->hex = JSObject_get_bool_field(format, "hex", false);
+  return (DelayedRequest*) req;
+}
+static bool request_variables(const JSObject* request) {
+  insert_to_request_queue(DelayedRequestVariables_create(request));
+  return true;
+}
+
+// "ContinueRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Continue request; value of command field is 'continue'.
+//                     The request starts the debuggee to run again.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "continue" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/ContinueArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "ContinueArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'continue' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Continue execution for the specified thread (if
+//                       possible). If the backend cannot continue on a single
+//                       thread but will continue on all threads, it should
+//                       set the allThreadsContinued attribute in the response
+//                       to true."
+//     }
+//   },
+//   "required": [ "threadId" ]
+// },
+// "ContinueResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'continue' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "allThreadsContinued": {
+//             "type": "boolean",
+//             "description": "If true, the continue request has ignored the
+//                             specified thread and continued all threads
+//                             instead. If this attribute is missing a value
+//                             of 'true' is assumed for backward
+//                             compatibility."
+//           }
+//         }
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+typedef DelayedRequest DelayedRequestContinue;
+static void DelayedRequestContinue_handle(DelayedRequest* req) {
+  disable_all_safepoints();
+  run_mode = RUN_MODE_RUNNING;
+  stack_trace_available = true;
+
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, req, NULL);
+  JSBuilder_object_field_begin(&builder, "body");
+  {
+    JSBuilder_write_bool_field(&builder, "allThreadsContinued", true);
+  }
+  JSBuilder_object_field_end(&builder); // body
+  JSBuilder_send_and_destroy_response(&builder);
+}
+static inline DelayedRequest* DelayedRequestContinue_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestContinue), &DelayedRequestContinue_handle);
+}
+static bool request_continue(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const int64_t thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  // Remember the thread ID that caused the resume so we can set the
+  // "threadCausedFocus" boolean value in the "stopped" events.
+  // g_vsc.focus_tid = GetUnsigned(arguments, "threadId", LLDB_INVALID_THREAD_ID);
+  insert_to_request_queue(DelayedRequestContinue_create(request));
+  return true;
+}
+
+// "PauseRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Pause request; value of command field is 'pause'. The
+//     request suspenses the debuggee. The debug adapter first sends the
+//     PauseResponse and then a StoppedEvent (event type 'pause') after the
+//     thread has been paused successfully.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "pause" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/PauseArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "PauseArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'pause' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Pause execution for this thread."
+//     }
+//   },
+//   "required": [ "threadId" ]
+// },
+// "PauseResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'pause' request. This is just an
+//     acknowledgement, so no body field is required."
+//   }]
+// }s
+static bool request_pause(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const int64_t thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  respond_to_request(request, NULL);
+  if (run_mode == RUN_MODE_PAUSED) {
+    send_thread_stopped(STOP_REASON_PAUSE, "Paused", 0);
+  } else {
+    run_mode = RUN_MODE_RUNNING;
+    enable_all_safepoints();
+  }
+  return true;
+}
+
+// "StepInRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "StepIn request; value of command field is 'stepIn'. The
+//     request starts the debuggee to step into a function/method if possible.
+//     If it cannot step into a target, 'stepIn' behaves like 'next'. The debug
+//     adapter first sends the StepInResponse and then a StoppedEvent (event
+//     type 'step') after the step has completed. If there are multiple
+//     function/method calls (or other targets) on the source line, the optional
+//     argument 'targetId' can be used to control into which target the 'stepIn'
+//     should occur. The list of possible targets for a given source line can be
+//     retrieved via the 'stepInTargets' request.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "stepIn" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/StepInArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "StepInArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'stepIn' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Execute 'stepIn' for this thread."
+//     },
+//     "targetId": {
+//       "type": "integer",
+//       "description": "Optional id of the target to step into."
+//     }
+//   },
+//   "required": [ "threadId" ]
+// },
+// "StepInResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'stepIn' request. This is just an
+//     acknowledgement, so no body field is required."
+//   }]
+// }
+typedef DelayedRequest DelayedRequestStepIn;
+static void DelayedRequestStepIn_handle(DelayedRequest* req) {
+  enable_all_safepoints();
+  run_mode = RUN_MODE_STEP_IN;
+  stack_trace_available = true;
+  respond_to_delayed_request(req, NULL);
+}
+static inline DelayedRequest* DelayedRequestStepIn_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestStepIn), &DelayedRequestStepIn_handle);
+}
+static bool request_stepIn(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const int64_t thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  insert_to_request_queue(DelayedRequestStepIn_create(request));
+  return true;
+}
+
+// "StepOutRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "StepOut request; value of command field is 'stepOut'. The
+//     request starts the debuggee to run again for one step. The debug adapter
+//     first sends the StepOutResponse and then a StoppedEvent (event type
+//     'step') after the step has completed.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "stepOut" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/StepOutArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "StepOutArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'stepOut' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Execute 'stepOut' for this thread."
+//     }
+//   },
+//   "required": [ "threadId" ]
+// },
+// "StepOutResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'stepOut' request. This is just an
+//     acknowledgement, so no body field is required."
+//   }]
+// }
+typedef DelayedRequest DelayedRequestStepOut;
+static void DelayedRequestStepOut_handle(DelayedRequest* req) {
+  enable_all_safepoints();
+  remember_stepping_context();
+  run_mode = RUN_MODE_STEP_OUT;
+  stack_trace_available = true;
+  respond_to_delayed_request(req, NULL);
+}
+static inline DelayedRequest* DelayedRequestStepOut_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestStepOut), &DelayedRequestStepOut_handle);
+}
+static bool request_stepOut(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const int64_t thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  insert_to_request_queue(DelayedRequestStepOut_create(request));
+  return true;
+}
+
+// "NextRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Next request; value of command field is 'next'. The
+//                     request starts the debuggee to run again for one step.
+//                     The debug adapter first sends the NextResponse and then
+//                     a StoppedEvent (event type 'step') after the step has
+//                     completed.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "next" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/NextArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "NextArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'next' request.",
+//   "properties": {
+//     "threadId": {
+//       "type": "integer",
+//       "description": "Execute 'next' for this thread."
+//     }
+//   },
+//   "required": [ "threadId" ]
+// },
+// "NextResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'next' request. This is just an
+//                     acknowledgement, so no body field is required."
+//   }]
+// }
+typedef DelayedRequest DelayedRequestNext;
+static void DelayedRequestNext_handle(DelayedRequest* req) {
+  enable_all_safepoints();
+  remember_stepping_context();
+  run_mode = RUN_MODE_STEP_OVER;
+  stack_trace_available = true;
+  respond_to_delayed_request(req, NULL);
+}
+static inline DelayedRequest* DelayedRequestNext_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestNext), &DelayedRequestNext_handle);
+}
+static bool request_next(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const int64_t thread_id = JSObject_get_integer_field(arguments, "threadId", INVALID_THREAD_ID);
+  insert_to_request_queue(DelayedRequestNext_create(request));
+  return true;
+}
+
+// "DisconnectRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Disconnect request; value of command field is
+//                     'disconnect'.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "disconnect" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/DisconnectArguments"
+//       }
+//     },
+//     "required": [ "command" ]
+//   }]
+// },
+// "DisconnectArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'disconnect' request.",
+//   "properties": {
+//     "terminateDebuggee": {
+//       "type": "boolean",
+//       "description": "Indicates whether the debuggee should be terminated
+//                       when the debugger is disconnected. If unspecified,
+//                       the debug adapter is free to do whatever it thinks
+//                       is best. A client can only rely on this attribute
+//                       being properly honored if a debug adapter returns
+//                       true for the 'supportTerminateDebuggee' capability."
+//     },
+//     "restart": {
+//       "type": "boolean",
+//       "description": "Indicates whether the debuggee should be restart
+//                       the process."
+//     }
+//   }
+// },
+// "DisconnectResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'disconnect' request. This is just an
+//                     acknowledgement, so no body field is required."
+//   }]
+// }
+typedef DelayedRequest DelayedRequestDisconnect;
+static void DelayedRequestDisconnect_handle(DelayedRequest* request) {
+  // TODO: call LoStanza function here.
+  const char* error = NULL;
+  JSBuilder builder;
+  JSBuilder_initialize_delayed_response(&builder, request, NULL);
+  JSBuilder_write_optional_string_field(&builder, "error", error);
+  JSBuilder_send_and_destroy_response(&builder);
+
+  if (!error) send_terminated();
+}
+static inline DelayedRequest* DelayedRequestDisconnect_create(const JSObject* request) {
+  return DelayedRequest_create(request, sizeof(DelayedRequestDisconnect), &DelayedRequestDisconnect_handle);
+}
+static bool request_disconnect(const JSObject* request) {
+  // TODO: Do we really need this?
+  // const JSObject* arguments = JSObject_get_object_field(request, "arguments");
+  // const bool terminate_debugee = JSObject_get_bool_field(arguments, "terminateDebugee", true);
+  // const bool restert = JSObject_get_bool_field(arguments, "restart", false);
+  insert_to_request_queue(DelayedRequestDisconnect_create(request));
+  return true;
+}
+
+#define FOR_EACH_REQUEST(def) \
+  def(continue)               \
+  def(disconnect)             \
+  def(initialize)             \
+  def(launch)                 \
+  def(pause)                  \
+  def(next)                   \
+  def(scopes)                 \
+  def(setBreakpoints)         \
+  def(setExceptionBreakpoints)\
+  def(source)                 \
+  def(stackTrace)             \
+  def(stepIn)                 \
+  def(stepOut)                \
+  def(threads)                \
+  def(variables)
+
+static const char* const request_names[] = {
+  #define DEFINE_REQUEST_NAME(name) #name,
+    FOR_EACH_REQUEST(DEFINE_REQUEST_NAME)
+  #undef DEFINE_REQUEST_NAME
+  NULL
+};
+// Request handler log the error and returns false for a malformed request.
+static bool (*request_handlers[])(const JSObject*) = {
+  #define DEFINE_REQUEST_HANDLER(name) request_##name,
+    FOR_EACH_REQUEST(DEFINE_REQUEST_HANDLER)
+  #undef DEFINE_REQUEST_HANDLER
+};
+#undef FOR_EACH_REQUEST
+
+static inline bool parse_request(JSValue* value, const char* data, size_t length) {
+  JSParser parser;
+  JSParser_initialize(&parser, data, length);
+  if (JSParser_parse_value(&parser, value) && JSParser_skip_spaces(&parser) != parser.limit)
+    JSParser_error(&parser, "Extra text after the object end");
+  if (parser.error[0]) {
+    log_printf("error: failed to parse JSON: %s\n", parser.error);
+    return false;
+  }
+  if (value->kind != JS_OBJECT) {
+    log_printf("error: received JSON is not an object\n");
+    return false;
+  }
+  JSObject* object = &value->u.o;
+  const char* type = JSObject_get_string_field(object, "type");
+  if (!type || strcmp(type, "request")) {
+    log_printf("error: received JSON 'type' field is not 'request'\n");
+    return false;
+  }
+  const char* command = JSObject_get_string_field(object, "command");
+  if (!command) {
+    log_printf("error: 'command' field of 'string' type expected\n");
+    return false;
+  }
+  for (const char* const* p = request_names; *p; p++)
+    if (!strcmp(*p, command))                             // request name matches the command?
+      return request_handlers[p - request_names](object); // call the request handler, return the result
+  log_printf("error: unhandled command '%s'\n");
+  return false;
+}
+
+static const char* canonicalize_request_name(const char* name) {
+  assert(name);
+  for (const char* const* p = request_names; *p; p++)
+    if (!strcmp(*p, name))
+      return *p;
+  return NULL;
+}
+
+typedef struct {
+  int argc;
+  char** argv;
+} Args;
+static inline void next_arg(Args* args) {
+  args->argc--;
+  args->argv++;
+}
+static bool is_arg(const char* name, Args* args) {
+  const char* arg = args->argv[0];
+  if (*arg++ == '-' && *arg++ == '-' && !strcmp(arg, name)) {
+    next_arg(args);
+    return true;
+  }
+  return false;
+}
+static char* get_arg_value(Args* args) {
+  if (args->argc) {
+    char* value = args->argv[0];
+    if (value[0] != '-' && value[1] != '-') {
+      next_arg(args);
+      return value;
+    }
+  }
+  fprintf(stderr, "Command-line parameter %s must be followed by a value\n", args->argv[0]);
+  exit(EXIT_FAILURE);
+  return NULL;
+}
+
+static inline void initialize_stanza_debugger(int argc, char** argv) {
+  // TODO: if necessary, call initialization of stanza debugger here. It runs on communication thread.
+}
+
+static void initialize_mutex(pthread_mutex_t* lock, const char* name) {
+  if (pthread_mutex_init(lock, NULL)) {
+    log_printf("error: initializing %s mutex (%s)\n", name, current_error());
+    exit(EXIT_FAILURE);
+  }
+}
+
+int main(int argc, char** argv) {
+  // Set line buffering mode to stdout and stderr
+  setvbuf(stdout, NULL, _IONBF, 0);
+  setvbuf(stderr, NULL, _IONBF, 0);
+
+  // Allocate and compute absolute path to the adapter
+  debug_adapter_path = get_absolute_path(argv[0]);
+  Args args = {argc, argv};
+  next_arg(&args);// Remove adapter from the args
+
+  const char* log_path = NULL;
+  char* port_arg = NULL;
+
+  while (args.argc > 0) {
+    if (is_arg("log", &args)) {
+      log_path = get_arg_value(&args);
+      continue;
+    }
+    if (is_arg("port", &args)) {
+      port_arg = get_arg_value(&args);
+      continue;
+    }
+    break;
+  }
+
+#if 0 // Currently unused
+  int launch_target_pos = find_last_arg_with_value("launch-target", argc, argv);
+  if (launch_target_pos) {
+    const int comm_file_pos = find_last_arg_with_value("comm-file", launch_target_pos, argv);
+    if (!comm_file_pos) {
+      fprintf(stderr, "--launch-target option requires --comm-file to be specified\n");
+      return EXIT_FAILURE;
+    }
+    ++launch_target_pos;
+    const char* comm_path = argv[comm_file_pos + 1];
+    char* const* launch_target_argv = argv + launch_target_pos;
+    const int launch_target_argc = argc - launch_target_pos;
+    launch_target_in_terminal(comm_path, launch_target_argc, launch_target_argv);
+  }
+
+#ifndef PLATFORM_WINDOWS
+  if (find_last_arg("wait-for-debugger", argc, argv)) {
+    printf("Paused waiting for debugger to attach (pid = %i)...\n", getpid());
+    pause();
+  }
+#endif
+#endif
+
+  if (log_path) {
+    debug_adapter_log = fopen(log_path, "wt");
+    if (!debug_adapter_log) {
+      fprintf(stderr, "error opening log file \"%s\" (%s)\n", log_path, current_error());
+      return EXIT_FAILURE;
+    }
+    if (setvbuf(debug_adapter_log, NULL, _IOLBF, BUFSIZ)) {
+      fprintf(stderr, "error setting line buffering mode for log file (%s)\n", current_error());
+      return EXIT_FAILURE;
+    }
+    if (pthread_mutex_init(&log_lock, NULL)) {
+      fprintf(debug_adapter_log, "error: initializing log mutex (%s)\n", current_error());
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (port_arg) {
+    char* remainder;
+    int port = strtoul(port_arg, &remainder, 0); // Ordinary C notation
+    if (*remainder) {
+      fprintf(stderr, "'%s' is not a valid port number.\n", port_arg);
+      return EXIT_FAILURE;
+    }
+
+    printf("Listening on port %i...\n", port);
+    SOCKET tmpsock = socket(AF_INET, SOCK_STREAM, 0);
+    if (tmpsock < 0) {
+      log_printf("error: opening socket (%s)\n", current_error());
+      return EXIT_FAILURE;
+    }
+
+    {
+      struct sockaddr_in serv_addr;
+      memclear(&serv_addr, sizeof serv_addr);
+      serv_addr.sin_family = AF_INET;
+      serv_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      serv_addr.sin_port = htons(port);
+      if (bind(tmpsock, (struct sockaddr*)&serv_addr, sizeof serv_addr) < 0) {
+        log_printf("error: binding socket (%s)\n", current_error());
+        return EXIT_FAILURE;
+      }
+    }
+    listen(tmpsock, 5);
+
+    SOCKET sock;
+    do {
+      struct sockaddr_in cli_addr;
+      socklen_t cli_addr_len = sizeof cli_addr;
+      sock = accept(tmpsock, (struct sockaddr*)&cli_addr, &cli_addr_len);
+    } while (sock < 0 && errno == EINTR);
+    if (sock < 0) {
+      log_printf("error: accepting socket (%s)\n", current_error());
+      return EXIT_FAILURE;
+    }
+    debug_adapter_socket = sock;
+    debug_adapter_read = &read_from_socket;
+    debug_adapter_write = &write_to_socket;
+  } else {
+    debug_adapter_input_fd = dup(fileno(stdin));
+    debug_adapter_output_fd = dup(fileno(stdout));
+    debug_adapter_read = &read_from_file;
+    debug_adapter_write = &write_to_file;
+  }
+
+  initialize_mutex(&send_lock, "send");
+  initialize_mutex(&request_queue_lock, "request queue");
+  initialize_mutex(&safepoint_lock, "safepoint");
+
+  // Initialize debugger with filtered argc, argv
+  initialize_stanza_debugger(args.argc, args.argv);
+
+  redirect_output(stdout, STDOUT);
+  redirect_output(stderr, STDERR);
+
+  for (char* data; run_mode != RUN_MODE_TERMINATED; free(data)) {
+    const ssize_t length = read_packet(&data);
+    if (!length) break;
+
+    JSValue received;
+    if (!parse_request(&received, data, length)) break;
+    JSValue_destroy(&received);
+  }
+
+  // Terminate debugger
+
+  sleep(1);
+
+  // free_path(debug_adapter_path); // OS will release the process memory
+  return EXIT_SUCCESS;
+}

--- a/core/debug/debug-adapter.c
+++ b/core/debug/debug-adapter.c
@@ -1,12 +1,10 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
-#include <inttypes.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #ifdef PLATFORM_WINDOWS
   #include <fcntl.h>
@@ -18,6 +16,8 @@
   #include <unistd.h>
   typedef int SOCKET;
 #endif
+
+#include "safepoints.h"
 
 static inline void* memclear(void* data, size_t size) {
   return memset(data, 0, size);
@@ -117,69 +117,9 @@ static inline void free_path(const char* s) {
   free((char*)s);
 }
 
-enum {
-  NOP = 0x90,
-  INT3 = 0xCC
-};
-
-typedef const struct {
-  uint8_t* const address;
-  const uint64_t group;
-} SafepointAddress;
-
-typedef const struct {
-  const uint64_t length;
-  SafepointAddress addresses[];
-} AddressList;
-static void AddressList_write(AddressList* list, const uint8_t inst) {
-  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
-    *p->address = inst;
-}
-static inline SafepointAddress* AddressList_find(AddressList* list, const void* pc) {
-  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
-    if (p->address == pc)
-      return p;
-  return NULL;
-}
-
-typedef const struct {
-  const uint64_t line;
-  AddressList* const address_list;
-} SafepointEntry;
-static inline void SafepointEntry_write(SafepointEntry* entry, const uint8_t inst) {
-  AddressList_write(entry->address_list, inst);
-}
-static SafepointAddress* SafepointEntry_find(SafepointEntry* entry, const void* pc) {
-  return AddressList_find(entry->address_list, pc);
-}
-
-typedef const struct {
-  const uint64_t num_entries;
-  const char* const filename;
-  SafepointEntry entries[];
-} FileSafepoints;
-static void FileSafepoints_write(FileSafepoints* file, const uint8_t inst) {
-  for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
-    SafepointEntry_write(entry, inst);
-}
-static inline SafepointEntry* FileSafepoints_find(FileSafepoints* file, uint64_t line) {
-  if (file)
-    for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
-      if (entry->line >= line)
-        return entry;
-  return NULL;
-}
-
-typedef const struct {
-  const uint64_t num_files;
-  FileSafepoints* const files[];
-} SafepointTable;
 SafepointTable* app_safepoint_table;
 static void Safepoints_write(const uint8_t inst) {
-  SafepointTable* safepoints = app_safepoint_table;
-  if (safepoints)
-    for (uint64_t i = 0, num_files = app_safepoint_table->num_files; i < num_files; i++)
-      FileSafepoints_write(safepoints->files[i], inst);
+  SafepointTable_write(app_safepoint_table, inst);
 }
 static FileSafepoints* Safepoints_find_file(const char* file_name) {
   const char* file_path = get_absolute_path(file_name);

--- a/core/debug/debug-adapter.c
+++ b/core/debug/debug-adapter.c
@@ -1,10 +1,6 @@
-#include <assert.h>
-#include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdarg.h>
-#include <stdbool.h>
-#include <stdio.h>
 #include <string.h>
 #ifdef PLATFORM_WINDOWS
   #include <fcntl.h>

--- a/core/debug/debug-adapter.stanza
+++ b/core/debug/debug-adapter.stanza
@@ -1,0 +1,599 @@
+defpackage debug-adapter :
+  import core
+  import collections
+  import reader
+  import core/debug/read-stack-trace
+  import core/debug-table
+  import core/dynamic-library
+  import core/local-table
+  import core/parsed-path
+  import core/sighandler
+  import core/stack-trace
+  import stz/absolute-info
+
+defn load-program (filename:String) -> DynamicLibrary :
+  val lib = dynamic-library-open(filename)
+  unprotect-extents(lib)
+  println("Load program succeeded.")
+  lib
+  ;set-sighandler(command-loop{lib, true})
+  ;try :
+  ;  command-loop(lib, false)
+  ;catch (e:Exception) :
+  ;  println(e)
+
+;<comment>
+defn* command-loop (lib:DynamicLibrary,
+                    running?:True|False) -> False :
+  let loop () :
+    val tokens = read-line(LineNoisePrompter("debug> ", "     > "))
+    match(tokens:List<Token>) :
+      match-syntax(tokens) :
+        (safepoints) :
+          print-safepoints(lib)
+          loop()
+        (break ?filename ?line) :
+          set-safepoint(lib, unwrap-token(filename) as String, unwrap-token(line) as Int)
+          loop()
+        (run) :
+          if running? :
+            println("Program is already running.")
+            loop()
+          else :
+            run-main(lib)
+            println("debug> Program finished.")
+        (continue) :
+          if running? :
+            false
+          else :
+            println("Program is not yet running.")
+            loop()
+        (stop) :
+          println("Stopping the program.")
+          throw(Exception("Program Stopped."))
+        (_ ...) :
+          println("Unrecognized command.")
+          loop()
+    else :
+      println("No command entered.")
+      loop()
+;<comment>
+
+lostanza val PAGE-SIZE:long = 4096
+lostanza defn align-down-to-page-size (p:ptr<?>) -> ptr<?> :
+  val x = p as long
+  val y = x & (- PAGE-SIZE)
+  return y as ptr<?>
+lostanza defn align-up-to-page-size (p:ptr<?>) -> ptr<?> :
+  return align-down-to-page-size(p + (PAGE-SIZE - 1))
+extern mprotect: (ptr<?>, long, int) -> int
+lostanza defn unprotect-extents (lib:ref<DynamicLibrary>) -> ref<False> :
+  val start = dynamic-library-symbol(lib, String("stanza_text_section_start"))
+  val end = dynamic-library-symbol(lib, String("stanza_text_section_end"))
+  val start-address = align-down-to-page-size(start.address)
+  val end-address = align-up-to-page-size(end.address)
+  call-c mprotect(start-address, end-address - start-address, 0x7)
+  return false
+
+lostanza defn to-bool (x:long) -> ref<True|False> :
+  if x : return true
+  else : return false
+
+defn absolute-file-path (base:String, file:String) -> String :
+  to-string(relative-to-dir(parse-path(base), file))
+
+lostanza val STACK-FRAME-FORMAT-HEX               : long = 1L << 0
+lostanza val STACK-FRAME-FORMAT-PARAMETERS        : long = 1L << 1
+lostanza val STACK-FRAME-FORMAT-PARAMETER-TYPES   : long = 1L << 2
+lostanza val STACK-FRAME-FORMAT-PARAMETER-NAMES   : long = 1L << 3
+lostanza val STACK-FRAME-FORMAT-PARAMETER-VALUES  : long = 1L << 4
+lostanza val STACK-FRAME-FORMAT-LINE              : long = 1L << 5
+lostanza val STACK-FRAME-FORMAT-MODULE            : long = 1L << 6
+lostanza val STACK-FRAME-FORMAT-INCLUDE-ALL       : long = 1L << 7
+
+lostanza defn include-all? (format:long) -> ref<True|False> :
+  return to-bool(format & STACK-FRAME-FORMAT-INCLUDE-ALL)
+
+extern append_stack_frame: (long, long, ptr<?>, ptr<?>, long, long) -> int
+lostanza defn append (instruction-pointer:ref<Long>, stack-pointer:ref<Long>,
+                      function:ref<String>, path:ref<String>, line:ref<Int>, column:ref<Int>) -> ref<False> :
+  call-c append_stack_frame(instruction-pointer.value, stack-pointer.value,
+                            addr!(function.chars), addr!(path.chars), line.value, column.value)
+  return false
+lostanza defn read-app-stack-trace () -> ref<SingleStackTrace> :
+  return read-stack-trace(app-vms)
+defn function-name (function:String|False) -> String :
+  match(function) :
+    (name:String) : name
+    (name) : "(unnamed)"
+defn create-stack-trace (include-all:True|False) :
+  for entry in entries(read-app-stack-trace()) do :
+    if include-all or package(entry) != `core :
+      match(info(entry)) :
+        (info:AbsoluteFileInfo) :
+          append(instruction-pointer(entry), stack-pointer(entry), function-name(signature(entry)),
+                 absolute-file-path(base(info), filename(info)), line(info), column(info))
+        (info) : false
+public extern defn create_stack_trace (format:long) -> int :
+  create-stack-trace(include-all?(format))
+  return 0
+
+public extern defn number_of_globals () -> int :
+  return count-globals().value
+defn count-globals () -> Int :
+  var count:Int = 0
+  defn inc (DebugEntry) : count = count + 1
+  for-all-globals(inc)
+  count
+
+public extern defn number_of_locals (pc:long) -> int :
+  return count-locals(new Long{pc}).value
+defn count-locals (pc:Long) -> Int :
+  val ctxt = local-context(pc)
+  match(ctxt:VarContext) :
+    length(ctxt)
+  else :
+    0
+
+;Variable visibility and const attributes
+lostanza val VARIABLE_PUBLIC    : byte = 1Y
+lostanza val VARIABLE_PRIVATE   : byte = 2Y
+lostanza val VARIABLE_PROTECTED : byte = 3Y
+lostanza val VARIABLE_CONSTANT  : byte = 4Y
+
+extern append_variable: (ptr<?>, ptr<byte>, ptr<byte>, ptr<byte>, long, byte) -> int
+lostanza defn append-variable (ref:ptr<?>, name:ref<String>, type:ref<String>, value:ref<String>, field-count:long) -> ref<False> :
+  call-c append_variable(ref, addr!(name.chars), addr!(type.chars), addr!(value.chars), field-count, 0Y)
+  return false
+lostanza defn append-variable (name:ref<String>, type:ref<String>, value:ref<String>) -> ref<False>:
+  return append-variable(null, name, type, value, 0L)
+lostanza defn append-variable (name:ref<String>, p:ptr<long>) -> ref<False> :
+  val v = [p]
+  return append-variable(p, name, type-of(v), string-of(v), field-count-of(v))
+lostanza defn append-variable (name:ref<Symbol>, p:ptr<long>) -> ref<False> :
+  return append-variable(to-string(name), p)
+lostanza defn append-variable (name:ref<Symbol>, offset:ref<Int>) -> ref<False> :
+  return append-variable(name, offset-to-address(offset))
+lostanza defn offset-to-address (offset:ref<Int>) -> ptr<long> :
+  return addr(app-vms.global-mem[offset.value]) as ptr<long>
+
+var hex:True|False = false
+defn field-name (offset:Long) :
+  to-string("field@%_" % [offset])
+lostanza defn field-name (p:ptr<long>, base:ptr<?>, field-names:ptr<ptr<byte>>, field-index:int) -> ref<String> :
+  if (field-names != null) :
+    return String(field-names[field-index])
+  return field-name(new Long{p - base})
+lostanza defn append-field (p:ptr<long>, base:ptr<?>, field-names:ptr<ptr<byte>>, field-index:int) -> ref<False> :
+  return append-variable(field-name(p, base, field-names, field-index), p)
+defn array-field-name (name:String, index:Long) :
+  to-string("%_[%_]" % [name index])
+defn array-field-name (index:Long) :
+  array-field-name("field", index)
+lostanza defn array-field-name (i:long, field-names:ptr<ptr<byte>>, field-index:int) -> ref<String> :
+  val index = new Long{i}
+  if (field-names != null) :
+    return array-field-name(String(field-names[field-index]), index)
+  return array-field-name(index)
+lostanza defn append-array-field (p:ptr<long>, i:long, field-names:ptr<ptr<byte>>, field-index:int) -> ref<False> :
+  return append-variable(array-field-name(i, field-names, field-index), p)
+public extern defn create_globals (hex:long) -> int :
+  /hex = to-bool(hex)
+  append-global-variables()
+  return 0
+public extern defn create_locals (pc:long, sp:long, hex:long) -> int :
+  /hex = to-bool(hex)
+  append-local-variables(new Long{pc}, new Long{sp})
+  return 0
+public extern defn create_fields (ref:ptr<long>, name:ptr<byte>, hex:long) -> int :
+  /hex = to-bool(hex)
+  val v = [ref]
+  val tag = type-id(v)
+  if tag > FLOAT-TAG-BITS :
+    val obj = (v - REF-TAG-BITS) as ptr<ObjectLayout>
+    val descriptor = addr(app-vms.class-table[tag])
+    var root-names:ptr<ptr<byte>> = descriptor.root-names
+    val case = descriptor.case
+    if case == FAST-LAYOUT-BASE-WITH-REFS :
+      val num-slots = descriptor.num-base-bytes >> 3
+      for (var i:int = 0, i < num-slots, i = i + 1) :
+        append-field(addr(obj.slots[i]), obj, root-names, i)
+    else if case == FAST-LAYOUT-ARRAY-REF-TAIL :
+      val len = obj.slots[0]
+      val tail = addr(obj.slots) + descriptor.num-base-bytes
+      for (var i:int = 0, i < len, i = i + 1) :
+        append-array-field(addr(tail[i]), i, root-names, 0)
+    else if case == FAST-LAYOUT-GENERAL :
+      ;General case: Use the full layout record
+      val class-rec = descriptor.record
+      if class-rec.item-size == 0 :
+        val roots = addr(class-rec.roots)
+        val num-roots = class-rec.num-roots
+        for (var i:int = 0, i < num-roots, i = i + 1) :
+          val r = roots[i]
+          append-field(addr(obj.slots[r]), obj, root-names, i)
+      ;Array class
+      else :
+        val array-rec = class-rec as ptr<core/ArrayRecord>
+        val num-base-roots = array-rec.num-base-roots
+        val base-roots = addr(array-rec.roots)
+        for (var i:int = 0, i < num-base-roots, i = i + 1) :
+          val r = base-roots[i]
+          append-field(addr(obj.slots[r]), obj, root-names, i)
+        val num-item-roots = array-rec.num-item-roots
+        if num-item-roots > 0 :
+          if root-names != null :
+            root-names = addr(root-names[num-base-roots])
+          var items:ptr<?> = addr(obj.slots) + array-rec.base-size
+          val item-size = array-rec.item-size
+          val item-roots = addr(array-rec.roots[num-base-roots])
+          val len = obj.slots[0]
+          for (var n:long = 0, n < len, n = n + 1) :
+            for (var i:int = 0, i < num-item-roots, i = i + 1) :
+              append-array-field(items + item-roots[i], n, root-names, i)
+            items = items + item-size
+  return 0
+defn append-global-variables () :
+  for-all-globals(append-variable)
+defn append-variable (entry:DebugEntry) :
+  append-variable(name(entry), offset(entry))
+defn for-all-globals (f: (DebugEntry)-> False) :
+  val table = get-debug-table(LOADED-PROGRAM)
+  for i in 0 to num-packages(table) do :
+    val package-table = table[i]
+    if name(package-table) != `core :
+      for i in 0 to num-entries(package-table) do :
+        f(package-table[i])
+lostanza defn local-context (pc:ref<Long>) -> ref<VarContext|False> :
+  val local-var-table = LocalVarTable(app-vms.local-var-table)
+  return context(local-var-table, pc)
+defn append-local-variables (pc:Long, sp:Long) :
+  val ctxt = local-context(pc)
+  match(ctxt:VarContext) :
+    for i in 0 to length(ctxt) do :
+      append-local-variable(ctxt[i], sp)
+    false
+  else :
+    false
+lostanza defn append-local-variable (v:ref<NamedVar>, sp:ref<Long>) -> ref<False> :
+  return append-variable(name(v), sp.value as ptr<long> + stack-offset(v).value as long)
+lostanza defn get-debug-table (lib:ref<DynamicLibrary>) -> ref<DebugTable> :
+  val debug-table-sym = dynamic-library-symbol(lib, String("stanza_debug_table"))
+  return DebugTable(debug-table-sym.address as ptr<DebugTableLayout>)
+lostanza defn type-of (v:long) -> ref<String> :
+  val type-id = type-id(v)
+  if type-id < 0 : return String("Unknown")
+  if type-id == tagof(core/Box) : return type-of(unbox(v))
+  return String(app-class-name(type-id))
+lostanza defn app-class-name (x:long) -> ptr<byte> :
+  val record = app-vms.class-table[x].record
+  return (record + record.num-bytes) as ptr<byte>
+
+;Borrowed from core
+lostanza val FAST-LAYOUT-BASE-WITH-NO-REFS:int = 0
+lostanza val FAST-LAYOUT-BASE-WITH-REFS:int = 1
+lostanza val FAST-LAYOUT-ARRAY-1-BYTE-TAIL:int = 2
+lostanza val FAST-LAYOUT-ARRAY-4-BYTE-TAIL:int = 3
+lostanza val FAST-LAYOUT-ARRAY-8-BYTE-TAIL:int = 4
+lostanza val FAST-LAYOUT-ARRAY-REF-TAIL:int = 5
+lostanza val FAST-LAYOUT-GENERAL:int = 6
+
+lostanza defn field-count-of (v:long) -> long :
+  val tag = type-id(v)
+  if tag <= FLOAT-TAG-BITS : return 0L
+  if tag == tagof(core/Box) : return 0L
+
+  val obj = (v - REF-TAG-BITS) as ptr<ObjectLayout>
+  val descriptor = addr(app-vms.class-table[tag])
+  val case = descriptor.case
+  if case == FAST-LAYOUT-BASE-WITH-REFS :
+    return descriptor.num-base-bytes >> 3
+  if case == FAST-LAYOUT-ARRAY-REF-TAIL :
+    return obj.slots[0]
+  if case == FAST-LAYOUT-GENERAL :
+    val class-rec = descriptor.record
+    if class-rec.item-size == 0 :
+      return class-rec.num-roots as long
+    ;Array class
+    else :
+      val array-rec = class-rec as ptr<core/ArrayRecord>
+      val num-base-roots = array-rec.num-base-roots
+      val num-item-roots = array-rec.num-item-roots
+      val len = obj.slots[0]
+      return num-item-roots * len + num-base-roots
+  return 0L
+
+;Borrowed from core
+lostanza val INT-TAG-BITS:long = 0L
+lostanza val REF-TAG-BITS:long = 1L
+lostanza val MARKER-TAG-BITS:long = 2L
+lostanza val BYTE-TAG-BITS:long = 3L
+lostanza val CHAR-TAG-BITS:long = 4L
+lostanza val FLOAT-TAG-BITS:long = 5L
+
+lostanza defn type-id (ref:long) -> long :
+  val tagbits = ref & 0x7L
+  if tagbits == INT-TAG-BITS : return tagof(Int)
+  if tagbits == BYTE-TAG-BITS : return tagof(Byte)
+  if tagbits == CHAR-TAG-BITS : return tagof(Char)
+  if tagbits == FLOAT-TAG-BITS : return tagof(Float)
+  if tagbits == MARKER-TAG-BITS : return ref >>> 3L ;Must be signed to make tagof(Void) negative
+  if tagbits == REF-TAG-BITS : return [(ref - REF-TAG-BITS) as ptr<long>]
+  return -2L
+
+lostanza defn untag (x:long) -> ptr<?> :
+  #if-not-defined(OPTIMIZE) :
+    val tagbits = x & 7L
+    if tagbits != 1 : fatal("Not a heap-allocated object!")
+  return (x - 1 + 8) as ptr<?>
+
+deftype RecognizedType :
+  True <: RecognizedType
+  False <: RecognizedType
+  Byte <: RecognizedType
+  Char <: RecognizedType
+  Int <: RecognizedType
+  Float <: RecognizedType
+  Long <: RecognizedType
+  Double <: RecognizedType
+  String <: RecognizedType
+  core/Box <: RecognizedType
+  AppByteArray <: RecognizedType
+  AppCharArray <: RecognizedType
+  AppIntArray <: RecognizedType
+  AppLongArray <: RecognizedType
+  AppFloatArray <: RecognizedType
+  AppDoubleArray <: RecognizedType
+  AppTuple <: RecognizedType
+  AppFullList <: RecognizedType
+  core/NilList <: RecognizedType
+  AppObject <: RecognizedType
+
+lostanza defn unbox (v:long) -> long :
+  return (untag(v) as ptr<core/Box>).item as long
+lostanza defn value-of (v:long) -> ref<RecognizedType> :
+  val type-id = type-id(v)
+  if type-id == tagof(False) :
+    return v as ref<False>
+  if type-id == tagof(True) :
+    return v as ref<True>
+  if type-id == tagof(Byte) :
+    return v as ref<Byte>
+  if type-id == tagof(Char) :
+    return v as ref<Char>
+  if type-id == tagof(Int) :
+    return v as ref<Int>
+  if type-id == tagof(Float) :
+    return v as ref<Float>
+  if type-id == tagof(Long) :
+    return Long(untag(v) as ptr<Long>)
+  if type-id == tagof(Double) :
+    return Double(untag(v) as ptr<Double>)
+  if type-id == tagof(String) :
+    return String(untag(v) as ptr<String>)
+  if type-id == tagof(StringSymbol) :
+    return String(untag(v) as ptr<StringSymbol>)
+  if type-id == tagof(core/Box) :
+    return value-of(unbox(v))
+  if type-id == tagof(ByteArray) :
+    return AppByteArray(v)
+  if type-id == tagof(CharArray) :
+    return AppCharArray(v)
+  if type-id == tagof(IntArray) :
+    return AppIntArray(v)
+  if type-id == tagof(LongArray) :
+    return AppLongArray(v)
+  if type-id == tagof(FloatArray) :
+    return AppFloatArray(v)
+  if type-id == tagof(DoubleArray) :
+    return AppDoubleArray(v)
+  if type-id == tagof(Tuple) :
+    return AppTuple(v)
+  if type-id == tagof(core/FullList) :
+    return AppFullList(v)
+  if type-id == tagof(core/NilList) :
+    return new core/NilList{}
+  return AppObject(v)
+
+defn to-source-string (c:Char) :
+  to-string("%~" % [c])
+defn to-source-string (s:String) :
+  to-string("%~" % [s])
+lostanza defn string-of (v:long) -> ref<String> :
+  val type-id = type-id(v)
+  if type-id == -1L : ;tagof(Void)
+    return String("(uninitialized)")
+  if type-id == tagof(False) :
+    return to-string(v as ref<False>)
+  if type-id == tagof(True) :
+    return to-string(v as ref<True>)
+  if type-id == tagof(Byte) :
+    return to-string(v as ref<Byte>)
+  if type-id == tagof(Char) :
+    return to-source-string(v as ref<Char>)
+  if type-id == tagof(Int) :
+    return to-string(v as ref<Int>)
+  if type-id == tagof(Float) :
+    return to-string(v as ref<Float>)
+  if type-id == tagof(Long) :
+    return to-string(Long(untag(v) as ptr<Long>))
+  if type-id == tagof(Double) :
+    return to-string(Double(untag(v) as ptr<Double>))
+  if type-id == tagof(String) :
+    return to-source-string(String(untag(v) as ptr<String>))
+  if type-id == tagof(StringSymbol) :
+    return String(untag(v) as ptr<StringSymbol>)
+  if type-id == tagof(core/Box) :
+    return string-of(unbox(v))
+  if type-id == tagof(ByteArray) :
+    return to-string(AppByteArray(v))
+  if type-id == tagof(CharArray) :
+    return to-string(AppCharArray(v))
+  if type-id == tagof(IntArray) :
+    return to-string(AppIntArray(v))
+  if type-id == tagof(LongArray) :
+    return to-string(AppLongArray(v))
+  if type-id == tagof(FloatArray) :
+    return to-string(AppFloatArray(v))
+  if type-id == tagof(DoubleArray) :
+    return to-string(AppDoubleArray(v))
+  if type-id == tagof(Tuple) :
+    return to-string(AppTuple(v))
+  if type-id == tagof(core/FullList) :
+    return to-string(AppFullList(v))
+  if type-id == tagof(core/NilList) :
+    return to-string(new core/NilList{})
+  return to-string(AppObject(v))
+
+;Here ptr<t> is always a pointer to the app heap,
+;so no allocations in the debugger heap can change it.
+lostanza defn Long (p:ptr<Long>) -> ref<Long> :
+  return new Long{p.value}
+lostanza defn Double (p:ptr<Double>) -> ref<Double> :
+  return new Double{p.value}
+lostanza defn String (p:ptr<String>) -> ref<String> :
+  return String(p.length - 1, addr!(p.chars))
+lostanza defn String (p:ptr<StringSymbol>) -> ref<String> :
+  return String(untag(p.name as long) as ptr<String>)
+
+lostanza deftype AppByteArray <: IndexedCollection<Byte> & Unique :
+  p:ptr<ByteArray>
+lostanza defmethod length (a:ref<AppByteArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppByteArray>, i:ref<Int>) -> ref<Byte> :
+  core/ensure-index-in-bounds(a, i)
+  return new Byte{a.p.data[i.value]}
+lostanza defn AppByteArray (v:long) -> ref<AppByteArray> :
+  val p = untag(v) as ptr<ByteArray>
+  return new AppByteArray{p}
+
+lostanza deftype AppCharArray <: IndexedCollection<Char> & Unique :
+  p:ptr<CharArray>
+lostanza defmethod length (a:ref<AppCharArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppCharArray>, i:ref<Int>) -> ref<Char> :
+  core/ensure-index-in-bounds(a, i)
+  return new Char{a.p.chars[i.value]}
+lostanza defn AppCharArray (v:long) -> ref<AppCharArray> :
+  val p = untag(v) as ptr<CharArray>
+  return new AppCharArray{p}
+
+lostanza deftype AppIntArray <: IndexedCollection<Int> & Unique :
+  p:ptr<IntArray>
+lostanza defmethod length (a:ref<AppIntArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppIntArray>, i:ref<Int>) -> ref<Int> :
+  core/ensure-index-in-bounds(a, i)
+  return new Int{a.p.data[i.value]}
+lostanza defn AppIntArray (v:long) -> ref<AppIntArray> :
+  val p = untag(v) as ptr<IntArray>
+  return new AppIntArray{p}
+
+lostanza deftype AppLongArray <: IndexedCollection<Long> & Unique :
+  p:ptr<LongArray>
+lostanza defmethod length (a:ref<AppLongArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppLongArray>, i:ref<Int>) -> ref<Long> :
+  core/ensure-index-in-bounds(a, i)
+  return new Long{a.p.data[i.value]}
+lostanza defn AppLongArray (v:long) -> ref<AppLongArray> :
+  val p = untag(v) as ptr<LongArray>
+  return new AppLongArray{p}
+
+lostanza deftype AppFloatArray <: IndexedCollection<Float> & Unique :
+  p:ptr<FloatArray>
+lostanza defmethod length (a:ref<AppFloatArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppFloatArray>, i:ref<Int>) -> ref<Float> :
+  core/ensure-index-in-bounds(a, i)
+  return new Float{a.p.data[i.value]}
+lostanza defn AppFloatArray (v:long) -> ref<AppFloatArray> :
+  val p = untag(v) as ptr<FloatArray>
+  return new AppFloatArray{p}
+
+lostanza deftype AppDoubleArray <: IndexedCollection<Double> & Unique :
+  p:ptr<DoubleArray>
+lostanza defmethod length (a:ref<AppDoubleArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppDoubleArray>, i:ref<Int>) -> ref<Double> :
+  core/ensure-index-in-bounds(a, i)
+  return new Double{a.p.data[i.value]}
+lostanza defn AppDoubleArray (v:long) -> ref<AppDoubleArray> :
+  val p = untag(v) as ptr<DoubleArray>
+  return new AppDoubleArray{p}
+
+lostanza deftype AppTuple <: IndexedCollection<RecognizedType> & Unique :
+  p:ptr<Tuple>
+defn empty? (t:AppTuple) :
+  length(t) == 0
+lostanza defmethod length (t:ref<AppTuple>) -> ref<Int> :
+  return new Int{t.p.length as int}
+lostanza defmethod get (a:ref<AppTuple>, i:ref<Int>) -> ref<RecognizedType> :
+  core/ensure-index-in-bounds(a, i)
+  return value-of(a.p.items[i.value] as long)
+lostanza defn AppTuple (v:long) -> ref<AppTuple> :
+  val p = untag(v) as ptr<Tuple>
+  return new AppTuple{p}
+
+lostanza deftype AppFullList <: List :
+  p:ptr<core/FullList>
+lostanza defmethod head (x:ref<AppFullList>) -> ref<RecognizedType> :
+  return value-of(x.p.head as long)
+lostanza defmethod tail (x:ref<AppFullList>) -> ref<AppFullList|core/NilList> :
+  val v = x.p.tail as long
+  if (type-id(v) == tagof(core/FullList)) :
+    return AppFullList(v)
+  else :
+    return new core/NilList{}
+defmethod empty? (x:AppFullList) : false
+lostanza defn AppFullList (v:long) -> ref<AppFullList> :
+  val p = untag(v) as ptr<core/FullList>
+  return new AppFullList{p}
+
+lostanza deftype AppObject :
+  p:long
+lostanza defn type-of (o:ref<AppObject>) -> ref<String> :
+  return type-of(o.p)
+defmethod print (o:OutputStream, x:AppObject) :
+  print(o, "[%_ object]" % [type-of(x)])
+lostanza defn AppObject (v:long) -> ref<AppObject> :
+  return new AppObject{v}
+
+lostanza defn stop-at-entry () -> ref<False> :
+  app-vms = dynamic-library-symbol(LOADED-PROGRAM, String("stanza_vmstate")).address as ptr<core/VMState>
+  app_safepoint_table = app-vms.safepoint-table
+  app_coroutine_refs = addr(app-vms.current-coroutine-ptr)
+  call-c notify_stopped_at_entry()
+  return false
+
+lostanza defn hit-safepoint () -> ref<False>:
+  call-c notify_stopped_at_safepoint(get-sighandler-instruction-address().value)
+  return false
+
+lostanza defn run-main (lib:ref<DynamicLibrary>) -> ref<Int> :
+  val main-sym = dynamic-library-symbol(lib, String("main"))
+  val main = main-sym.address as ptr<( (int, ptr<ptr<byte>>) -> int )>
+  val result = call-c [main](clib/input_argc, clib/input_argv)
+  return new Int{result}
+
+extern notify_stopped_at_entry: () -> int
+extern notify_stopped_at_safepoint: (long) -> int
+extern app_safepoint_table:ptr<?>
+extern app_coroutine_refs:ptr<?>
+
+lostanza var app-vms:ptr<core/VMState> = null
+var LOADED-PROGRAM:DynamicLibrary
+
+defn main () :
+  val cmd-args = command-line-arguments()
+  ;println("Stanza: Command line arguments = %_" % [cmd-args])
+
+  val program-filename = cmd-args[0]
+  LOADED-PROGRAM = load-program(program-filename)
+
+  set-sighandler(hit-safepoint)
+  stop-at-entry()
+  run-main(LOADED-PROGRAM)
+
+
+main()

--- a/core/debug/debugger.c
+++ b/core/debug/debugger.c
@@ -1,0 +1,47 @@
+#include <signal.h>
+#include "safepoints.h"
+
+SafepointTable* app_safepoint_table;
+enum { RUN, STEP, NEXT };
+uint8_t run_mode;
+
+static bool all_safepoints_enabled;
+static void Safepoints_write(const uint8_t inst) {
+  if (app_safepoint_table)
+    SafepointTable_write(app_safepoint_table, inst);
+}
+
+void Safepoints_enable(void) {
+  if (!all_safepoints_enabled) {
+    all_safepoints_enabled = true;
+    Safepoints_write(INT3);
+  }
+}
+int Safepoints_disable(void) {
+  bool enabled = all_safepoints_enabled;
+  if (enabled) {
+    all_safepoints_enabled = false;
+    Safepoints_write(NOP);
+  }
+  return enabled;
+}
+void write_breakpoint(SafepointEntry* entry, const uint8_t inst) {
+  if (!all_safepoints_enabled)
+    SafepointEntry_write(entry, inst);
+}
+
+static void handler(int signal) {
+  run_mode = STEP;
+  Safepoints_enable();
+}
+void set_SIGINT_handler(void) {
+  //Create signal action
+  struct sigaction sa;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = handler;
+  sa.sa_flags = SA_ONSTACK | SA_RESTART;
+  if (sigaction(SIGINT, &sa, NULL)) {
+    perror("SIGINT handler");
+    exit(-1);
+  }
+}

--- a/core/debug/debugger.stanza
+++ b/core/debug/debugger.stanza
@@ -11,234 +11,695 @@ defpackage debugger :
   import core/stack-trace
   import core/local-table
 
-defn main () :
-  val filename = command-line-arguments()[1]
-  val lib = dynamic-library-open(filename)
-  unprotect-extents(lib)
-  val vartable = get-local-table(lib)
-  set-sighandler(command-loop{lib, vartable, true})
-  try :
-    command-loop(lib, vartable, false)
-  catch (e:Exception) :
-    println(e)
-
-defn* command-loop (lib:DynamicLibrary,
-                    vartable:LocalVarTable,
-                    running?:True|False) -> False :
-  if running? :
-    val rip = get-sighandler-instruction-address()
-    print-hit(rip)
-
+defn* command-loop (running?:True|False) -> False :
   let loop () :
     val tokens = read-line(LineNoisePrompter("debug> ", "     > "))
     match(tokens:List<Token>) :
       match-syntax(tokens) :
         (backtrace) :
-
           ;Check whether the program is running.
           if running? :
-
-            ;Read the stack trace of the running program.
-            val stack-trace = read-stack-trace(lib)
-
-            ;Print out unformatted
-            println(stack-trace)
-
-;            ;Filter out core packages.
-;            defn no-core-packages (package:Symbol, sig:String|False) -> True|False :
-;              package != `core
-;
-;            ;Print out the stack trace using the filter.
-;            print-stack-trace(current-output-stream(),
-;                              stack-trace,
-;                              no-core-packages)                              
-
-          ;If program is not running, then don't print out the
-          ;backtrace.
+            ;Filter out core packages.
+            defn no-core-packages (package:Symbol, sig:String|False) -> True|False :
+              package != `core
+            ;Print out the stack trace using the filter.
+            print-stack-trace(current-output-stream(), read-app-stack-trace(), no-core-packages)
           else :
             println("Program is not running.")
-
           ;Do not advance the program.
           loop()
-          
         (safepoints) :
-          print-safepoints(lib)
+          print-safepoints()
           loop()
-        (variables) :
-          print-all-variables(lib)
+        (globals) :
+          print-globals()
           loop()
         (locals ?ip-token ?sp-token) :
           val ip = unwrap-token(ip-token) as Long
           val sp = unwrap-token(sp-token) as Long
-          val ctxt = context(vartable, ip)
-          match(ctxt:VarContext) :
-            if length(ctxt) == 0 :
-              println("No named locals recorded.")
-            else :
-              for i in 0 to length(ctxt) do :
-                val v = ctxt[i]
-                println("Variable %_ = %_" % [name(v), read-int-at-stack-offset(stack-offset(v), sp)])
-          else :
-            println("No locals recorded.")
+          print-locals(ip, sp)
           loop()
         (locals) :
-          val rip = get-sighandler-instruction-address()
-          val ctxt = context(vartable, rip)
-          match(ctxt:VarContext) :
-            if length(ctxt) == 0 :
-              println("No named locals recorded.")
-            else :
-              for i in 0 to length(ctxt) do :
-                val v = ctxt[i]
-                println("Variable %_ = %_" % [name(v), read-int-at-stack-offset(stack-offset(v))])
-          else :
-            println("No locals recorded.")
+          val ip = get-sighandler-instruction-address()
+          val sp = get-sighandler-stack-pointer()
+          print-locals(ip, sp)
           loop()
         (break ?filename ?line) :
-          set-safepoint(lib, unwrap-token(filename) as String, unwrap-token(line) as Int)
+          set-breakpoint(unwrap-token(filename) as String, unwrap-token(line) as Int)
           loop()
-        (print ?offset) :
-          match(unwrap-token(offset)) :
-            (offset:Int) : print-int-at-offset(lib, offset)
-            (name:Symbol) : print-int-with-name(lib, name)
+        (unbreak ?filename ?line) :
+          clear-breakpoint(unwrap-token(filename) as String, unwrap-token(line) as Int)
           loop()
-        (run) :
-          if running? :
-            println("Program is already running.")
-            loop()
-          else :
-            run-main(lib)
-            println("debug> Program finished.")
+        (breakpoints) :
+          breakpoints()
+          loop()
         (continue) :
           if running? :
-            false
+            continue()
           else :
-            println("Program is not yet running.")
-            loop()
+            run()
+        (step) :
+          step()
+          if running? == false :
+            run()
+        (next) :
+          next()
+          if running? == false :
+            run()
         (stop) :
-          println("Stopping the program.")
-          throw(Exception("Program Stopped."))        
+          if running? :
+            println("Stopping the program.")
+          throw(Exception("Program stopped."))
+        (quit) :
+          quit()
+        (help) :
+          print-help(false)
+          loop()
         (_ ...) :
-          println("Unrecognized command.")
+          print-help("Unrecognized command.")
           loop()
     else :
-      println("Quitting.")
-      exit(0)
+      quit()
 
-lostanza defn print-hit (address:ref<Long>) -> ref<False> :
-  val p = address.value as ptr<?>
-  call-c clib/printf("Hit breakpoint at %lld\n", p)
+val help = [
+  "Available commands:\n"
+  "  backtrace\n"
+  "  break \"source-file-name\" line\n"
+  "  breakpoints\n"
+  "  continue\n"
+  "  globals\n"
+  "  locals        ;topmost stack frame\n"
+  "  locals ip sp\n"
+  "  next\n"
+  "  quit\n"
+  "  step\n"
+  "  stop\n"
+  "  safepoints    ;necessary for debug-mode testing\n"
+  "  unbreak \"source-file-name\" line\n"
+  "  help\n"
+  ]
+defn print-help (msg:String|False) :
+  match(msg:String) : println(msg)
+  println-all(help)
+
+defn run () :
+  println("debug> Program finished wth completion code %_." % [run-main()])
+defn quit () :
+  println("Quitting.")
+  exit(0)
+
+lostanza defn read-app-stack-trace () -> ref<SingleStackTrace> :
+  return read-stack-trace(app-vms)
+
+lostanza defn print-safepoints () -> ref<False> :
+  return dump-safepoint-table(app-safepoints())
+
+lostanza defn set-breakpoint (filename:ref<String>, line:ref<Int>) -> ref<False> :
+  return set-breakpoint(addr!(filename.chars), line.value)
+lostanza defn set-breakpoint (filename:ptr<byte>, line:int) -> ref<False> :
+  val entry = safepoint-entry(filename, line)
+  if (entry != null) :
+    if (find(active-safepoints, entry) != null) :
+      call-c clib/printf("Breakpoint is already set at %s:%d\n", filename, line)
+    else :
+      insert(active-safepoints, entry)
+      set-breakpoint(entry)
   return false
 
+lostanza defn clear-breakpoint (filename:ref<String>, line:ref<Int>) -> ref<False> :
+  return clear-breakpoint(addr!(filename.chars), line.value)
+lostanza defn clear-breakpoint (filename:ptr<byte>, line:int) -> ref<False> :
+  val entry = safepoint-entry(filename, line)
+  if (entry != null) :
+    val p = find(active-safepoints, entry)
+    if (p == null) :
+      call-c clib/printf("No breakpoint set at %s:%d\n", filename, line)
+    else :
+      [p] = null
+      clear-breakpoint(entry)
+  return false
+
+lostanza defn safepoint-entry (filename:ptr<byte>, line:int) -> ptr<SafepointEntry> :
+  val safepoints:ptr<FileSafepoints> = file-safepoints(app-safepoints(), filename)
+  if (safepoints == null) :
+    call-c clib/printf("No safepoints in %s\n", filename)
+  else :
+    for (var i:long = 0, i < safepoints.num-entries, i = i + 1) :
+      val entry = addr(safepoints.entries[i])
+      if entry.line == line : return entry
+    call-c clib/printf("No safepoint at %s:%d\n", filename, line)
+  return null
+
+lostanza defn set-breakpoint (entry:ptr<SafepointEntry>) -> ref<False> :
+  return write-breakpoint(entry, INSTRUCTION-INT3)
+lostanza defn clear-breakpoint (entry:ptr<SafepointEntry>) -> ref<False> :
+  return write-breakpoint(entry, INSTRUCTION-NOP)
+lostanza defn write-breakpoint (entry:ptr<SafepointEntry>, inst:byte) -> ref<False> :
+  call-c write_breakpoint(entry, inst)
+  return false
+lostanza val INSTRUCTION-INT3:byte = 0xCCY
+lostanza val INSTRUCTION-NOP:byte = 0x90Y
+
+extern Safepoints_enable : () -> int
+extern Safepoints_disable : () -> int
+extern write_breakpoint : (ptr<SafepointEntry>, byte) -> int
+
+lostanza defn enable-all-safepoints () -> ref<False> :
+  call-c Safepoints_enable()
+  return false
+lostanza defn disable-all-safepoints () -> ref<False> :
+  if (call-c Safepoints_disable() != 0) :
+    restore-active-safepoints()
+  return false
+lostanza defn restore-active-safepoints () -> ref<False> :
+  return write(active-safepoints, INSTRUCTION-INT3)
+
+lostanza defn breakpoints () -> ref<False> :
+  val safepoints = app-safepoints()
+  for (var i:long = 0, i < safepoints.num-files, i = i + 1) :
+    breakpoints(safepoints.files[i])
+  return false
+lostanza defn breakpoints (safepoints:ptr<FileSafepoints>) -> ref<False> :
+  for (var i:long = 0, i < safepoints.num-entries, i = i + 1) :
+    val entry = addr(safepoints.entries[i])
+    if (find(active-safepoints, entry) != null) :
+      call-c clib/printf("Breakpoint at %s:%d\n", safepoints.filename, entry.line as int)
+  return false
+
+lostanza defn find-file (safepoints:ptr<SafepointTable>, entry:ptr<SafepointEntry>) -> ptr<FileSafepoints> :
+  for (var i:long = 0, i < safepoints.num-files, i = i + 1) :
+    val file = safepoints.files[i]
+    val dist = entry - addr(file.entries)
+    if (dist >= 0 and dist < (sizeof(SafepointEntry) * file.num-entries)) :
+      return file
+  return null
+lostanza defn find (safepoints:ptr<SafepointTable>, ip:ptr<?>) -> ptr<SafepointEntry> :
+  for (var i:long = 0, i < safepoints.num-files, i = i + 1) :
+    val entry = find(safepoints.files[i], ip)
+    if (entry != null) :
+      return entry
+  return null
+lostanza defn find (safepoints:ptr<FileSafepoints>, ip:ptr<?>) -> ptr<SafepointEntry> :
+  for (var i:long = 0, i < safepoints.num-entries, i = i + 1) :
+    val entry = addr(safepoints.entries[i])
+    if (find(entry, ip) != null) :
+      return entry
+  return null
+lostanza defn find (entry:ptr<SafepointEntry>, ip:ptr<?>) -> ptr<SafepointAddress> :
+  return find(entry.address-list, ip)
+lostanza defn find (list:ptr<AddressList>, ip:ptr<?>) -> ptr<SafepointAddress> :
+  for (var i:long = 0, i < list.length, i = i + 1) :
+    val p = addr(list.addresses[i])
+    if (p.address == ip) :
+      return p
+  return null
+
+defn print-locals (ip:Long, sp:Long) :
+  val ctxt = context(app-locals, ip)
+  match(ctxt:VarContext) :
+    if length(ctxt) == 0 :
+      println("No named locals recorded.")
+    else :
+      for i in 0 to length(ctxt) do :
+        print-local-variable(ctxt[i], sp)
+  else :
+    println("No locals recorded.")
+
+defn print-globals () -> False :
+  val table = app-globals
+  for i in 0 to num-packages(table) do :
+    val package-table = table[i]
+    if name(package-table) != `core and num-entries(package-table) > 0 :
+      println("Package %_" % [name(package-table)])
+      for j in 0 to num-entries(package-table) do :
+        print-global-variable(package-table[j])
+
+lostanza defn print-local-variable (v:ref<NamedVar>, sp:ref<Long>) -> ref<False> :
+  return print-variable(name(v), sp.value as ptr<long> + stack-offset(v).value)
+lostanza defn print-global-variable (v:ref<DebugEntry>) -> ref<False> :
+  return print-variable(to-string(name(v)), app-vms.global-mem as ptr<long> + offset(v).value)
+lostanza defn print-variable (name:ref<String>, p:ptr<long>) -> ref<False> :
+  val v = [p]
+  return print-variable(name, type-of(v), string-of(v))
+defn print-variable (name:String, type:String, value:String) :
+  println("  var %_ : %_ = %_" % [name, type, value])
+
+lostanza defn run-main () -> ref<Int> :
+  val main = app-main as ptr<( (int, ptr<ptr<byte>>) -> int )>
+  val result = call-c [main](clib/input_argc - 1, addr(clib/input_argv[1]))
+  return new Int{result}
+
+lostanza defn load-app (path:ref<String>) -> ref<False>:
+  val lib = dynamic-library-open(path)
+  unprotect-code(lib)
+  val vms = vmstate(lib).address as ptr<core/VMState>
+  app-vms = vms
+  app_safepoint_table = app-vms.safepoint-table ;Export safepoint table to native code
+  app-locals = LocalVarTable(vms.local-var-table)
+  app-globals = DebugTable(vms.debug-table)
+  app-main = dynamic-library-symbol(lib, String("main")).address
+  call-c set_SIGINT_handler()
+  return false
+defn vmstate (lib:DynamicLibrary) :
+  dynamic-library-symbol(lib, String("stanza_vmstate"))
+lostanza defn app-safepoints () -> ptr<SafepointTable> :
+  return app_safepoint_table
+extern set_SIGINT_handler : () -> int
+
+lostanza defn unprotect-code (lib:ref<DynamicLibrary>) -> ref<False> :
+  val start = dynamic-library-symbol(lib, String("stanza_text_section_start")).address
+  val end = dynamic-library-symbol(lib, String("stanza_text_section_end")).address
+  val start-page = align-down-to-page-size(start)
+  val limit-page = align-down-to-page-size(end + (PAGE-SIZE - 1L))
+  call-c mprotect(start-page, limit-page - start-page, 0x7)
+  return false
+extern mprotect: (ptr<?>, long, int) -> int
 lostanza val PAGE-SIZE:long = 4096
-lostanza defn align-to-page-size (p:ptr<?>) -> ptr<?> :
+lostanza defn align-down-to-page-size (p:ptr<?>) -> ptr<?> :
   val x = p as long
   val y = x & (- PAGE-SIZE)
   return y as ptr<?>
 
-extern mprotect: (ptr<?>, long, int) -> int
-lostanza defn unprotect-region (p1:ptr<?>, p2:ptr<?>) -> ref<False> :
-  var p:ptr<?> = p1
-  while p <= p2 :
-    val result = call-c mprotect(p, PAGE-SIZE, 0x7)
-    p = p + PAGE-SIZE
-  return false
+;Debugger state
+lostanza var app-vms : ptr<core/VMState>
+lostanza var app-main : ptr<?>
+var app-locals : LocalVarTable
+var app-globals : DebugTable
 
-lostanza defn unprotect-extents (lib:ref<DynamicLibrary>) -> ref<False> :
-  val start = dynamic-library-symbol(lib, String("stanza_text_section_start"))
-  val end = dynamic-library-symbol(lib, String("stanza_text_section_end"))
-  val start-address = align-to-page-size(start.address)
-  val end-address = align-to-page-size(end.address)
-  unprotect-region(start-address, end-address)
-  return false
+extern app_safepoint_table : ptr<SafepointTable>
 
-lostanza defn get-safepoint-table (lib:ref<DynamicLibrary>) -> ptr<SafepointTable> :
-  val safepoint-sym = dynamic-library-symbol(lib, String("stanza_safepoint_table"))
-  return safepoint-sym.address as ptr<SafepointTable>
+;Borrowed from core
+lostanza val INT-TAG-BITS:long = 0L
+lostanza val REF-TAG-BITS:long = 1L
+lostanza val MARKER-TAG-BITS:long = 2L
+lostanza val BYTE-TAG-BITS:long = 3L
+lostanza val CHAR-TAG-BITS:long = 4L
+lostanza val FLOAT-TAG-BITS:long = 5L
 
-lostanza defn print-safepoints (lib:ref<DynamicLibrary>) -> ref<False> :
-  dump-safepoint-table(get-safepoint-table(lib))
-  return false
+;Borrowed from debug-adapter
+lostanza defn type-id (ref:long) -> long :
+  val tagbits = ref & 0x7L
+  if tagbits == INT-TAG-BITS : return tagof(Int)
+  if tagbits == BYTE-TAG-BITS : return tagof(Byte)
+  if tagbits == CHAR-TAG-BITS : return tagof(Char)
+  if tagbits == FLOAT-TAG-BITS : return tagof(Float)
+  if tagbits == MARKER-TAG-BITS : return ref >>> 3L ;Must be signed to make tagof(Void) negative
+  if tagbits == REF-TAG-BITS : return [(ref - REF-TAG-BITS) as ptr<long>]
+  return -2L
 
-lostanza defn set-safepoint (lib:ref<DynamicLibrary>, filename:ref<String>, line:ref<Int>) -> ref<False> :
-  val table = get-safepoint-table(lib)
-  val address-list = safepoint-addresses(table, addr!(filename.chars), line.value)
-  if address-list == null :
-    call-c clib/printf("No safepoint at %s:%ld\n", addr!(filename.chars), line.value)
+public lostanza defn type-of (v:long) -> ref<String> :
+  val type-id = type-id(v)
+  if type-id < 0 : return String("Unknown")
+  if type-id == tagof(core/Box) : return type-of(unbox(v))
+  return String(app-class-name(type-id))
+lostanza defn app-class-name (x:long) -> ptr<byte> :
+  val record = app-vms.class-table[x].record
+  return (record + record.num-bytes) as ptr<byte>
+
+lostanza defn untag (x:long) -> ptr<?> :
+  #if-not-defined(OPTIMIZE) :
+    val tagbits = x & 7L
+    if tagbits != 1 : fatal("Not a heap-allocated object!")
+  return (x - 1 + 8) as ptr<?>
+
+deftype RecognizedType :
+  True <: RecognizedType
+  False <: RecognizedType
+  Byte <: RecognizedType
+  Char <: RecognizedType
+  Int <: RecognizedType
+  Float <: RecognizedType
+  Long <: RecognizedType
+  Double <: RecognizedType
+  String <: RecognizedType
+  core/Box <: RecognizedType
+  AppByteArray <: RecognizedType
+  AppCharArray <: RecognizedType
+  AppIntArray <: RecognizedType
+  AppLongArray <: RecognizedType
+  AppFloatArray <: RecognizedType
+  AppDoubleArray <: RecognizedType
+  AppTuple <: RecognizedType
+  AppFullList <: RecognizedType
+  core/NilList <: RecognizedType
+  AppObject <: RecognizedType
+
+lostanza defn unbox (v:long) -> long :
+  return (untag(v) as ptr<core/Box>).item as long
+
+lostanza defn value-of (v:long) -> ref<RecognizedType> :
+  val type-id = type-id(v)
+  if type-id == tagof(False) :
+    return v as ref<False>
+  if type-id == tagof(True) :
+    return v as ref<True>
+  if type-id == tagof(Byte) :
+    return v as ref<Byte>
+  if type-id == tagof(Char) :
+    return v as ref<Char>
+  if type-id == tagof(Int) :
+    return v as ref<Int>
+  if type-id == tagof(Float) :
+    return v as ref<Float>
+  if type-id == tagof(Long) :
+    return Long(untag(v) as ptr<Long>)
+  if type-id == tagof(Double) :
+    return Double(untag(v) as ptr<Double>)
+  if type-id == tagof(String) :
+    return String(untag(v) as ptr<String>)
+  if type-id == tagof(StringSymbol) :
+    return String(untag(v) as ptr<StringSymbol>)
+  if type-id == tagof(core/Box) :
+    return value-of(unbox(v))
+  if type-id == tagof(ByteArray) :
+    return AppByteArray(v)
+  if type-id == tagof(CharArray) :
+    return AppCharArray(v)
+  if type-id == tagof(IntArray) :
+    return AppIntArray(v)
+  if type-id == tagof(LongArray) :
+    return AppLongArray(v)
+  if type-id == tagof(FloatArray) :
+    return AppFloatArray(v)
+  if type-id == tagof(DoubleArray) :
+    return AppDoubleArray(v)
+  if type-id == tagof(Tuple) :
+    return AppTuple(v)
+  if type-id == tagof(core/FullList) :
+    return AppFullList(v)
+  if type-id == tagof(core/NilList) :
+    return new core/NilList{}
+  return AppObject(v)
+
+defn to-source-string (c:Char) :
+  to-string("%~" % [c])
+defn to-source-string (s:String) :
+  to-string("%~" % [s])
+lostanza defn string-of (v:long) -> ref<String> :
+  val type-id = type-id(v)
+  if type-id == -1L : ;tagof(Void)
+    return String("(uninitialized)")
+  if type-id == tagof(False) :
+    return to-string(v as ref<False>)
+  if type-id == tagof(True) :
+    return to-string(v as ref<True>)
+  if type-id == tagof(Byte) :
+    return to-string(v as ref<Byte>)
+  if type-id == tagof(Char) :
+    return to-source-string(v as ref<Char>)
+  if type-id == tagof(Int) :
+    return to-string(v as ref<Int>)
+  if type-id == tagof(Float) :
+    return to-string(v as ref<Float>)
+  if type-id == tagof(Long) :
+    return to-string(Long(untag(v) as ptr<Long>))
+  if type-id == tagof(Double) :
+    return to-string(Double(untag(v) as ptr<Double>))
+  if type-id == tagof(String) :
+    return to-source-string(String(untag(v) as ptr<String>))
+  if type-id == tagof(StringSymbol) :
+    return String(untag(v) as ptr<StringSymbol>)
+  if type-id == tagof(core/Box) :
+    return string-of(unbox(v))
+  if type-id == tagof(ByteArray) :
+    return to-string(AppByteArray(v))
+  if type-id == tagof(CharArray) :
+    return to-string(AppCharArray(v))
+  if type-id == tagof(IntArray) :
+    return to-string(AppIntArray(v))
+  if type-id == tagof(LongArray) :
+    return to-string(AppLongArray(v))
+  if type-id == tagof(FloatArray) :
+    return to-string(AppFloatArray(v))
+  if type-id == tagof(DoubleArray) :
+    return to-string(AppDoubleArray(v))
+  if type-id == tagof(Tuple) :
+    return to-string(AppTuple(v))
+  if type-id == tagof(core/FullList) :
+    return to-string(AppFullList(v))
+  if type-id == tagof(core/NilList) :
+    return to-string(new core/NilList{})
+  return to-string(AppObject(v))
+
+;Here ptr<t> is always a pointer to the app heap,
+;so no allocations in the debugger heap can change it.
+lostanza defn Long (p:ptr<Long>) -> ref<Long> :
+  return new Long{p.value}
+lostanza defn Double (p:ptr<Double>) -> ref<Double> :
+  return new Double{p.value}
+lostanza defn String (p:ptr<String>) -> ref<String> :
+  return String(p.length - 1, addr!(p.chars))
+lostanza defn String (p:ptr<StringSymbol>) -> ref<String> :
+  return String(untag(p.name as long) as ptr<String>)
+
+lostanza deftype AppByteArray <: IndexedCollection<Byte> & Unique :
+  p:ptr<ByteArray>
+lostanza defmethod length (a:ref<AppByteArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppByteArray>, i:ref<Int>) -> ref<Byte> :
+  core/ensure-index-in-bounds(a, i)
+  return new Byte{a.p.data[i.value]}
+lostanza defn AppByteArray (v:long) -> ref<AppByteArray> :
+  val p = untag(v) as ptr<ByteArray>
+  return new AppByteArray{p}
+
+lostanza deftype AppCharArray <: IndexedCollection<Char> & Unique :
+  p:ptr<CharArray>
+lostanza defmethod length (a:ref<AppCharArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppCharArray>, i:ref<Int>) -> ref<Char> :
+  core/ensure-index-in-bounds(a, i)
+  return new Char{a.p.chars[i.value]}
+lostanza defn AppCharArray (v:long) -> ref<AppCharArray> :
+  val p = untag(v) as ptr<CharArray>
+  return new AppCharArray{p}
+
+lostanza deftype AppIntArray <: IndexedCollection<Int> & Unique :
+  p:ptr<IntArray>
+lostanza defmethod length (a:ref<AppIntArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppIntArray>, i:ref<Int>) -> ref<Int> :
+  core/ensure-index-in-bounds(a, i)
+  return new Int{a.p.data[i.value]}
+lostanza defn AppIntArray (v:long) -> ref<AppIntArray> :
+  val p = untag(v) as ptr<IntArray>
+  return new AppIntArray{p}
+
+lostanza deftype AppLongArray <: IndexedCollection<Long> & Unique :
+  p:ptr<LongArray>
+lostanza defmethod length (a:ref<AppLongArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppLongArray>, i:ref<Int>) -> ref<Long> :
+  core/ensure-index-in-bounds(a, i)
+  return new Long{a.p.data[i.value]}
+lostanza defn AppLongArray (v:long) -> ref<AppLongArray> :
+  val p = untag(v) as ptr<LongArray>
+  return new AppLongArray{p}
+
+lostanza deftype AppFloatArray <: IndexedCollection<Float> & Unique :
+  p:ptr<FloatArray>
+lostanza defmethod length (a:ref<AppFloatArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppFloatArray>, i:ref<Int>) -> ref<Float> :
+  core/ensure-index-in-bounds(a, i)
+  return new Float{a.p.data[i.value]}
+lostanza defn AppFloatArray (v:long) -> ref<AppFloatArray> :
+  val p = untag(v) as ptr<FloatArray>
+  return new AppFloatArray{p}
+
+lostanza deftype AppDoubleArray <: IndexedCollection<Double> & Unique :
+  p:ptr<DoubleArray>
+lostanza defmethod length (a:ref<AppDoubleArray>) -> ref<Int> :
+  return new Int{a.p.length as int}
+lostanza defmethod get (a:ref<AppDoubleArray>, i:ref<Int>) -> ref<Double> :
+  core/ensure-index-in-bounds(a, i)
+  return new Double{a.p.data[i.value]}
+lostanza defn AppDoubleArray (v:long) -> ref<AppDoubleArray> :
+  val p = untag(v) as ptr<DoubleArray>
+  return new AppDoubleArray{p}
+
+lostanza deftype AppTuple <: IndexedCollection<RecognizedType> & Unique :
+  p:ptr<Tuple>
+defn empty? (t:AppTuple) :
+  length(t) == 0
+lostanza defmethod length (t:ref<AppTuple>) -> ref<Int> :
+  return new Int{t.p.length as int}
+lostanza defmethod get (a:ref<AppTuple>, i:ref<Int>) -> ref<RecognizedType> :
+  core/ensure-index-in-bounds(a, i)
+  return value-of(a.p.items[i.value] as long)
+lostanza defn AppTuple (v:long) -> ref<AppTuple> :
+  val p = untag(v) as ptr<Tuple>
+  return new AppTuple{p}
+
+lostanza deftype AppFullList <: List :
+  p:ptr<core/FullList>
+lostanza defmethod head (x:ref<AppFullList>) -> ref<RecognizedType> :
+  return value-of(x.p.head as long)
+lostanza defmethod tail (x:ref<AppFullList>) -> ref<AppFullList|core/NilList> :
+  val v = x.p.tail as long
+  if (type-id(v) == tagof(core/FullList)) :
+    return AppFullList(v)
   else :
-    for (var i:long = 0, i < address-list.length, i = i + 1) :
-      write-int3(address-list.addresses[i].address)
+    return new core/NilList{}
+defmethod empty? (x:AppFullList) : false
+lostanza defn AppFullList (v:long) -> ref<AppFullList> :
+  val p = untag(v) as ptr<core/FullList>
+  return new AppFullList{p}
+
+lostanza deftype AppObject :
+  p:long
+lostanza defn type-of (o:ref<AppObject>) -> ref<String> :
+  return type-of(o.p)
+defmethod print (o:OutputStream, x:AppObject) :
+  print(o, "[%_ object]" % [type-of(x)])
+lostanza defn AppObject (v:long) -> ref<AppObject> :
+  return new AppObject{v}
+
+lostanza deftype SafepointEntrySet :
+  var capacity: int
+  var length: int
+  var items: ptr<ptr<SafepointEntry>>
+lostanza defn SafepointEntrySet () -> ptr<SafepointEntrySet> :
+  val v:ptr<SafepointEntrySet> = call-c clib/malloc(sizeof(SafepointEntrySet))
+  val capacity:int = 16
+  v.capacity = capacity
+  v.length = 0
+  v.items = call-c clib/malloc(capacity * sizeof(ptr<?>))
+  return v
+lostanza defn free (v:ptr<SafepointEntrySet>) -> ref<False> :
+  call-c clib/free(v.items)
+  call-c clib/free(v)
+  return false
+lostanza defn find (v:ptr<SafepointEntrySet>, e:ptr<SafepointEntry>) -> ptr<ptr<SafepointEntry>> :
+  var p:ptr<ptr<SafepointEntry>> = v.items
+  val limit:ptr<ptr<SafepointEntry>> = p + (v.length * sizeof(ptr<?>))
+  while (p < limit) :
+    if ([p] == e) : return p
+    p = p + sizeof(ptr<?>)
+  return null
+lostanza defn find-ip (v:ptr<SafepointEntrySet>, ip:ptr<?>) -> ptr<SafepointEntry> :
+  var p:ptr<ptr<SafepointEntry>> = v.items
+  val limit:ptr<ptr<SafepointEntry>> = p + (v.length * sizeof(ptr<?>))
+  while (p < limit) :
+    val entry = [p]
+    if (entry != null and find(entry, ip) != null) :
+      return entry
+    p = p + sizeof(ptr<?>)
+  return null
+lostanza defn write (v:ptr<SafepointEntrySet>, instruction:byte) -> ref<False> :
+  var p:ptr<ptr<SafepointEntry>> = v.items
+  val limit:ptr<ptr<SafepointEntry>> = p + (v.length * sizeof(ptr<?>))
+  while (p < limit) :
+    val entry = [p]
+    if (entry != null) :
+      write-breakpoint(entry, instruction)
+    p = p + sizeof(ptr<?>)
+  return false
+lostanza defn insert (v:ptr<SafepointEntrySet>, e:ptr<SafepointEntry>) -> ref<False> :
+  val p:ptr<ptr<SafepointEntry>> = find(v, null)
+  if (p != null) :
+    [p] = e
+  else :
+    val length = v.length
+    if length == v.capacity :
+      val capacity:int = v.capacity << 1
+      v.capacity = capacity
+      v.items = core/realloc(v.items, capacity * sizeof(ptr<?>))
+    v.items[length] = e
+    v.length = length + 1
+  return false
+lostanza val active-safepoints:ptr<SafepointEntrySet> = SafepointEntrySet()
+
+lostanza val RUN:byte  = 0Y
+lostanza val STEP:byte = 1Y
+lostanza val NEXT:byte = 2Y
+extern run_mode:byte
+
+lostanza var current-safepoint:ptr<SafepointEntry> = null
+lostanza defn set-current-safepoint (entry:ptr<SafepointEntry>, msg:ptr<byte>) -> ref<False> :
+  current-safepoint = entry
+  val file = find-file(app-safepoints(), entry)
+  if (file != null) :
+    call-c clib/printf("%s at %s:%ld\n", msg, file.filename, entry.line)
   return false
 
-lostanza defn get-local-table (lib:ref<DynamicLibrary>) -> ref<LocalVarTable> :
-  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
-  val vmstate = vmstate-sym.address as ptr<core/VMState>
-  return LocalVarTable(vmstate.local-var-table)
+lostanza defn continue () -> ref<False> :
+  run_mode = RUN
+  return disable-all-safepoints()
+lostanza defn step () -> ref<False> :
+  run_mode = STEP
+  return enable-all-safepoints()
+lostanza defn next () -> ref<False> :
+  val current-coroutine-ptr = current-coroutine-ptr()
+  if (current-coroutine-ptr != null) :
+    val current-coroutine = [current-coroutine-ptr]
+    val stepping-coroutine-ptr = stepping-coroutine-ptr()
+    [stepping-coroutine-ptr] = current-coroutine
+    stepping-safepoint = current-safepoint
+    stepping-stack-depth = current-stack-depth(current-coroutine)
+  run_mode = NEXT
+  return enable-all-safepoints()
 
-lostanza defn get-debug-table (lib:ref<DynamicLibrary>) -> ref<DebugTable> :
-  val debug-table-sym = dynamic-library-symbol(lib, String("stanza_debug_table"))
-  return DebugTable(debug-table-sym.address as ptr<DebugTableLayout>)
+lostanza var stepping-safepoint:ptr<SafepointEntry>
+lostanza var stepping-stack-depth:long
 
-lostanza defn read-stack-trace (lib:ref<DynamicLibrary>) -> ref<SingleStackTrace> :
-  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
-  val vmstate = vmstate-sym.address as ptr<core/VMState>
-  return read-stack-trace(vmstate)
+extern get_signal_handler_ip: () -> ptr<?>
+extern get_signal_handler_sp: () -> ptr<?>
 
-defn print-all-variables (lib:DynamicLibrary) -> False :
-  val table = get-debug-table(lib)
-  for i in 0 to num-packages(table) do :
-    val package-table = table[i]
-    println("Package %_" % [name(package-table)])
-    for i in 0 to num-entries(package-table) do :
-      val entry = package-table[i]
-      println("  Variable %~ at offset %_" % [name(entry), offset(entry)])
+lostanza defn current-coroutine-ptr () -> ptr<ref<core/RawCoroutine>> :
+  return app-vms.current-coroutine-ptr as ptr<ref<core/RawCoroutine>>
+lostanza defn stepping-coroutine-ptr () -> ptr<ref<core/RawCoroutine>> :
+  return app-vms.stepping-coroutine-ptr as ptr<ref<core/RawCoroutine>>
 
-defn get-variable-offset (lib:DynamicLibrary, name:Symbol) -> Int|False :
-  val table = get-debug-table(lib)
-  value? $ for i in 0 to num-packages(table) first :
-    val package-table = table[i]
-    for i in 0 to num-entries(package-table) first :
-      val entry = package-table[i]
-      if /name(entry) == name : One(offset(entry))
-      else : None()
+lostanza defn current-stack-depth (current_coroutine:ref<core/RawCoroutine>) -> long :
+  val sp = call-c get_signal_handler_sp();
+  if (sp == null) : return 0L
+  return sp - current_coroutine.stack.frames
 
-lostanza defn read-int (address:ptr<?>) -> ref<Int> :
-  val value = [address as ptr<long>]
-  return new Int{(value >> 32L) as int}
-
-lostanza defn read-int-at-stack-offset (offset:ref<Int>) -> ref<Int> :
-  val rsp = get-sighandler-stack-pointer().value as ptr<?>
-  return read-int(rsp + offset.value)
-
-lostanza defn read-int-at-stack-offset (offset:ref<Int>, sp:ref<Long>) -> ref<Int> :
-  val rsp = sp.value as ptr<?>
-  return read-int(rsp + offset.value)
-
-lostanza defn read-int-at-offset (lib:ref<DynamicLibrary>, offset:ref<Int>) -> ref<Int> :
-  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
-  val vmstate = vmstate-sym.address as ptr<core/VMState>
-  val value-ptr = addr(vmstate.global-mem[offset.value])
-  return read-int(value-ptr)
-
-defn print-int-at-offset (lib:DynamicLibrary, offset:Int) -> False :
-  println("Value = %_" % [read-int-at-offset(lib, offset)])
-
-defn print-int-with-name (lib:DynamicLibrary, name:Symbol) -> False :
-  match(get-variable-offset(lib, name)) :
-    (offset:Int) :
-      println("%_ = %_" % [name, read-int-at-offset(lib, offset)])
-    (f:False) :
-      println("No variable named '%~'" % [name])
-
-lostanza defn write-int3 (p:ptr<byte>) -> ref<False> :
-  call-c clib/printf("Set breakpoint at %p\n", p)
-  [p] = 0xCCY
+lostanza val COROUTINE-CLOSED:int = 1
+lostanza defn when-paused-at-safepoint () -> ref<False> :
+  val ip = call-c get_signal_handler_ip()
+  val breakpoint = find-ip(active-safepoints, ip)
+  if (breakpoint != null) :
+    set-current-safepoint(breakpoint, "Hit breakpoint")
+  else :
+    if (run_mode == NEXT and stepping-safepoint != null) :
+      val current-coroutine-ptr = current-coroutine-ptr()
+      val stepping-coroutine-ptr = stepping-coroutine-ptr()
+      if (current-coroutine-ptr != null) :
+        val current-coroutine = [current-coroutine-ptr]
+        val stepping-coroutine = [stepping-coroutine-ptr]
+        if (current-coroutine == stepping-coroutine and stepping-coroutine != false) :
+          if (stepping-coroutine.status.value != COROUTINE-CLOSED) :
+            val stack-depth = current-stack-depth(stepping-coroutine)
+            if (stack-depth >= stepping-stack-depth) :
+              if (stack-depth > stepping-stack-depth) :
+                return false
+              if (find(stepping-safepoint, ip) != null) :
+                return false
+    val safepoint = find(app-safepoints(), ip)
+    set-current-safepoint(safepoint, "Paused")
+  forget-stepping-coroutine()
+  stepping-safepoint = null
+  command-loop(true)
   return false
-  
-lostanza defn run-main (lib:ref<DynamicLibrary>) -> ref<Int> :
-  val main-sym = dynamic-library-symbol(lib, String("main"))
-  val main = main-sym.address as ptr<( (int, ptr<ptr<byte>>) -> int )>
-  val result = call-c [main](clib/input_argc - 1, addr(clib/input_argv[1]))
-  return new Int{result}
+lostanza defn forget-stepping-coroutine () -> ref<False> :
+  val stepping-coroutine-ptr = stepping-coroutine-ptr() as ptr<ref<False>>
+  if (stepping-coroutine-ptr != null) :
+    [stepping-coroutine-ptr] = false
+  return false
 
+defn main () :
+  val args = command-line-arguments()
+  if length(args) < 2 :
+    println("Usage: %_ app-path app-args")
+    exit(-1)
+  load-app(args[1])
+  set-sighandler(when-paused-at-safepoint)
+
+  println("Paused at entry")
+  try :
+    command-loop(false)
+  catch (e:Exception) :
+    println(e)
 main()

--- a/core/debug/debugger.stanza
+++ b/core/debug/debugger.stanza
@@ -1,0 +1,244 @@
+defpackage debugger :
+  import core
+  import collections
+  import reader
+  import core/dynamic-library
+  import core/safepoints
+  import core/debug-table
+  import core/sighandler
+  import stz/line-noise-prompter
+  import core/debug/read-stack-trace
+  import core/stack-trace
+  import core/local-table
+
+defn main () :
+  val filename = command-line-arguments()[1]
+  val lib = dynamic-library-open(filename)
+  unprotect-extents(lib)
+  val vartable = get-local-table(lib)
+  set-sighandler(command-loop{lib, vartable, true})
+  try :
+    command-loop(lib, vartable, false)
+  catch (e:Exception) :
+    println(e)
+
+defn* command-loop (lib:DynamicLibrary,
+                    vartable:LocalVarTable,
+                    running?:True|False) -> False :
+  if running? :
+    val rip = get-sighandler-instruction-address()
+    print-hit(rip)
+
+  let loop () :
+    val tokens = read-line(LineNoisePrompter("debug> ", "     > "))
+    match(tokens:List<Token>) :
+      match-syntax(tokens) :
+        (backtrace) :
+
+          ;Check whether the program is running.
+          if running? :
+
+            ;Read the stack trace of the running program.
+            val stack-trace = read-stack-trace(lib)
+
+            ;Print out unformatted
+            println(stack-trace)
+
+;            ;Filter out core packages.
+;            defn no-core-packages (package:Symbol, sig:String|False) -> True|False :
+;              package != `core
+;
+;            ;Print out the stack trace using the filter.
+;            print-stack-trace(current-output-stream(),
+;                              stack-trace,
+;                              no-core-packages)                              
+
+          ;If program is not running, then don't print out the
+          ;backtrace.
+          else :
+            println("Program is not running.")
+
+          ;Do not advance the program.
+          loop()
+          
+        (safepoints) :
+          print-safepoints(lib)
+          loop()
+        (variables) :
+          print-all-variables(lib)
+          loop()
+        (locals ?ip-token ?sp-token) :
+          val ip = unwrap-token(ip-token) as Long
+          val sp = unwrap-token(sp-token) as Long
+          val ctxt = context(vartable, ip)
+          match(ctxt:VarContext) :
+            if length(ctxt) == 0 :
+              println("No named locals recorded.")
+            else :
+              for i in 0 to length(ctxt) do :
+                val v = ctxt[i]
+                println("Variable %_ = %_" % [name(v), read-int-at-stack-offset(stack-offset(v), sp)])
+          else :
+            println("No locals recorded.")
+          loop()
+        (locals) :
+          val rip = get-sighandler-instruction-address()
+          val ctxt = context(vartable, rip)
+          match(ctxt:VarContext) :
+            if length(ctxt) == 0 :
+              println("No named locals recorded.")
+            else :
+              for i in 0 to length(ctxt) do :
+                val v = ctxt[i]
+                println("Variable %_ = %_" % [name(v), read-int-at-stack-offset(stack-offset(v))])
+          else :
+            println("No locals recorded.")
+          loop()
+        (break ?filename ?line) :
+          set-safepoint(lib, unwrap-token(filename) as String, unwrap-token(line) as Int)
+          loop()
+        (print ?offset) :
+          match(unwrap-token(offset)) :
+            (offset:Int) : print-int-at-offset(lib, offset)
+            (name:Symbol) : print-int-with-name(lib, name)
+          loop()
+        (run) :
+          if running? :
+            println("Program is already running.")
+            loop()
+          else :
+            run-main(lib)
+            println("debug> Program finished.")
+        (continue) :
+          if running? :
+            false
+          else :
+            println("Program is not yet running.")
+            loop()
+        (stop) :
+          println("Stopping the program.")
+          throw(Exception("Program Stopped."))        
+        (_ ...) :
+          println("Unrecognized command.")
+          loop()
+    else :
+      println("Quitting.")
+      exit(0)
+
+lostanza defn print-hit (address:ref<Long>) -> ref<False> :
+  val p = address.value as ptr<?>
+  call-c clib/printf("Hit breakpoint at %lld\n", p)
+  return false
+
+lostanza val PAGE-SIZE:long = 4096
+lostanza defn align-to-page-size (p:ptr<?>) -> ptr<?> :
+  val x = p as long
+  val y = x & (- PAGE-SIZE)
+  return y as ptr<?>
+
+extern mprotect: (ptr<?>, long, int) -> int
+lostanza defn unprotect-region (p1:ptr<?>, p2:ptr<?>) -> ref<False> :
+  var p:ptr<?> = p1
+  while p <= p2 :
+    val result = call-c mprotect(p, PAGE-SIZE, 0x7)
+    p = p + PAGE-SIZE
+  return false
+
+lostanza defn unprotect-extents (lib:ref<DynamicLibrary>) -> ref<False> :
+  val start = dynamic-library-symbol(lib, String("stanza_text_section_start"))
+  val end = dynamic-library-symbol(lib, String("stanza_text_section_end"))
+  val start-address = align-to-page-size(start.address)
+  val end-address = align-to-page-size(end.address)
+  unprotect-region(start-address, end-address)
+  return false
+
+lostanza defn get-safepoint-table (lib:ref<DynamicLibrary>) -> ptr<SafepointTable> :
+  val safepoint-sym = dynamic-library-symbol(lib, String("stanza_safepoint_table"))
+  return safepoint-sym.address as ptr<SafepointTable>
+
+lostanza defn print-safepoints (lib:ref<DynamicLibrary>) -> ref<False> :
+  dump-safepoint-table(get-safepoint-table(lib))
+  return false
+
+lostanza defn set-safepoint (lib:ref<DynamicLibrary>, filename:ref<String>, line:ref<Int>) -> ref<False> :
+  val table = get-safepoint-table(lib)
+  val address-list = safepoint-addresses(table, addr!(filename.chars), line.value)
+  if address-list == null :
+    call-c clib/printf("No safepoint at %s:%ld\n", addr!(filename.chars), line.value)
+  else :
+    for (var i:long = 0, i < address-list.length, i = i + 1) :
+      write-int3(address-list.addresses[i].address)
+  return false
+
+lostanza defn get-local-table (lib:ref<DynamicLibrary>) -> ref<LocalVarTable> :
+  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
+  val vmstate = vmstate-sym.address as ptr<core/VMState>
+  return LocalVarTable(vmstate.local-var-table)
+
+lostanza defn get-debug-table (lib:ref<DynamicLibrary>) -> ref<DebugTable> :
+  val debug-table-sym = dynamic-library-symbol(lib, String("stanza_debug_table"))
+  return DebugTable(debug-table-sym.address as ptr<DebugTableLayout>)
+
+lostanza defn read-stack-trace (lib:ref<DynamicLibrary>) -> ref<SingleStackTrace> :
+  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
+  val vmstate = vmstate-sym.address as ptr<core/VMState>
+  return read-stack-trace(vmstate)
+
+defn print-all-variables (lib:DynamicLibrary) -> False :
+  val table = get-debug-table(lib)
+  for i in 0 to num-packages(table) do :
+    val package-table = table[i]
+    println("Package %_" % [name(package-table)])
+    for i in 0 to num-entries(package-table) do :
+      val entry = package-table[i]
+      println("  Variable %~ at offset %_" % [name(entry), offset(entry)])
+
+defn get-variable-offset (lib:DynamicLibrary, name:Symbol) -> Int|False :
+  val table = get-debug-table(lib)
+  value? $ for i in 0 to num-packages(table) first :
+    val package-table = table[i]
+    for i in 0 to num-entries(package-table) first :
+      val entry = package-table[i]
+      if /name(entry) == name : One(offset(entry))
+      else : None()
+
+lostanza defn read-int (address:ptr<?>) -> ref<Int> :
+  val value = [address as ptr<long>]
+  return new Int{(value >> 32L) as int}
+
+lostanza defn read-int-at-stack-offset (offset:ref<Int>) -> ref<Int> :
+  val rsp = get-sighandler-stack-pointer().value as ptr<?>
+  return read-int(rsp + offset.value)
+
+lostanza defn read-int-at-stack-offset (offset:ref<Int>, sp:ref<Long>) -> ref<Int> :
+  val rsp = sp.value as ptr<?>
+  return read-int(rsp + offset.value)
+
+lostanza defn read-int-at-offset (lib:ref<DynamicLibrary>, offset:ref<Int>) -> ref<Int> :
+  val vmstate-sym = dynamic-library-symbol(lib, String("stanza_vmstate"))
+  val vmstate = vmstate-sym.address as ptr<core/VMState>
+  val value-ptr = addr(vmstate.global-mem[offset.value])
+  return read-int(value-ptr)
+
+defn print-int-at-offset (lib:DynamicLibrary, offset:Int) -> False :
+  println("Value = %_" % [read-int-at-offset(lib, offset)])
+
+defn print-int-with-name (lib:DynamicLibrary, name:Symbol) -> False :
+  match(get-variable-offset(lib, name)) :
+    (offset:Int) :
+      println("%_ = %_" % [name, read-int-at-offset(lib, offset)])
+    (f:False) :
+      println("No variable named '%~'" % [name])
+
+lostanza defn write-int3 (p:ptr<byte>) -> ref<False> :
+  call-c clib/printf("Set breakpoint at %p\n", p)
+  [p] = 0xCCY
+  return false
+  
+lostanza defn run-main (lib:ref<DynamicLibrary>) -> ref<Int> :
+  val main-sym = dynamic-library-symbol(lib, String("main"))
+  val main = main-sym.address as ptr<( (int, ptr<ptr<byte>>) -> int )>
+  val result = call-c [main](clib/input_argc - 1, addr(clib/input_argv[1]))
+  return new Int{result}
+
+main()

--- a/core/debug/safepoints.h
+++ b/core/debug/safepoints.h
@@ -1,0 +1,70 @@
+#ifndef SAFEPOINTS_H
+#define SAFEPOINTS_H
+
+#include <inttypes.h>
+#include <stdlib.h>
+
+enum {
+  NOP = 0x90,
+  INT3 = 0xCC
+};
+
+typedef const struct {
+  uint8_t* const address;
+  const uint64_t group;
+} SafepointAddress;
+
+typedef const struct {
+  const uint64_t length;
+  SafepointAddress addresses[];
+} AddressList;
+static inline void AddressList_write(AddressList* list, const uint8_t inst) {
+  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
+    *p->address = inst;
+}
+static inline SafepointAddress* AddressList_find(AddressList* list, const void* pc) {
+  for (SafepointAddress *p = list->addresses, *lim = p + list->length; p < lim; p++)
+    if (p->address == pc)
+      return p;
+  return NULL;
+}
+
+typedef const struct {
+  const uint64_t line;
+  AddressList* const address_list;
+} SafepointEntry;
+static inline void SafepointEntry_write(SafepointEntry* entry, const uint8_t inst) {
+  AddressList_write(entry->address_list, inst);
+}
+static inline SafepointAddress* SafepointEntry_find(SafepointEntry* entry, const void* pc) {
+  return AddressList_find(entry->address_list, pc);
+}
+
+typedef const struct {
+  const uint64_t num_entries;
+  const char* const filename;
+  SafepointEntry entries[];
+} FileSafepoints;
+static inline void FileSafepoints_write(FileSafepoints* file, const uint8_t inst) {
+  for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
+    SafepointEntry_write(entry, inst);
+}
+static inline SafepointEntry* FileSafepoints_find(FileSafepoints* file, uint64_t line) {
+  if (file)
+    for (SafepointEntry *entry = file->entries, *lim = entry + file->num_entries; entry < lim; entry++)
+      if (entry->line >= line)
+        return entry;
+  return NULL;
+}
+
+typedef const struct {
+  const uint64_t num_files;
+  FileSafepoints* const files[];
+} SafepointTable;
+static inline void SafepointTable_write(SafepointTable* safepoints, const uint8_t inst) {
+  if (safepoints)
+    for (uint64_t i = 0, num_files = safepoints->num_files; i < num_files; i++)
+      FileSafepoints_write(safepoints->files[i], inst);
+}
+
+#endif // SAFEPOINTS_H

--- a/core/debug/safepoints.h
+++ b/core/debug/safepoints.h
@@ -1,8 +1,12 @@
 #ifndef SAFEPOINTS_H
 #define SAFEPOINTS_H
 
+#include <assert.h>
+#include <ctype.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 enum {
   NOP = 0x90,

--- a/core/debug/stanza.proj
+++ b/core/debug/stanza.proj
@@ -1,0 +1,3 @@
+package debugger defined-in "debugger.stanza"
+package debug-adapter defined-in "debug-adapter.stanza"
+

--- a/runtime/driver.c
+++ b/runtime/driver.c
@@ -1178,7 +1178,14 @@ static stz_long bitset_size (stz_long heap_size) {
   return ROUND_UP_TO_WHOLE_PAGES(bitset_size_in_longs << LOG_BYTES_IN_LONG);
 }
 
+#ifdef BUILD_DEBUG_ADAPTER
+int stanza_main (int argc, char* argv[]) {
+  //printf("C: Running program with %d arguments:\n", argc);
+  //for (char** p = argv; *p != NULL; p++)
+  //  printf("  \"%s\"\n", *p);
+#else
 STANZA_API_FUNC int main (int argc, char* argv[]) {
+#endif
   input_argc = (stz_int)argc;
   input_argv = (stz_byte **)argv;
   input_argv_needs_free = 0;

--- a/scripts/finish-debug.sh
+++ b/scripts/finish-debug.sh
@@ -1,0 +1,4 @@
+../stanza ../core/stanza.proj ../compiler/stanza.proj dummy.stanza -s dummy.s
+STANZADIR="/Users/patricksli/Docs/Programming/stanzadev"
+gcc dummy.s $STANZADIR/runtime/driver.c $STANZADIR/runtime/debug.c $STANZADIR/core/sighandler.c $STANZADIR/runtime/linenoise.c -DBUILD_DEBUG -std=gnu99 -ldl -DPLATFORM_OS_X -I$STANZADIR/include -o dummy -D_XOPEN_SOURCE
+cp dummy $STANZADIR/runtime/debug

--- a/scripts/lfinish-debug.sh
+++ b/scripts/lfinish-debug.sh
@@ -1,0 +1,9 @@
+#scripts/make-asmjit.sh linux
+#gcc -std=gnu99 -c core/sha256.c -O3 -o build/sha256.o -fPIC -I include
+#gcc -std=gnu99 -c compiler/cvm.c -O3 -o build/cvm.o -fPIC -I include
+#gcc -std=gnu99 core/threadedreader.c runtime/driver.c runtime/linenoise.c build/cvm.o build/sha256.o lstanza.s -o lstanza -DPLATFORM_LINUX -lm -ldl -fPIC -I include -Lbin -lasmjit-linux -lstdc++ -lrt -lpthread
+
+../stanza ../core/stanza.proj ../compiler/stanza.proj ../core/debug/stanza.proj debug-adapter -s debug-adapter.s -pkg ../pkgs -optimize
+STANZADIR=/home/opliss/Work/lbstanza
+cc debug-adapter.s -DBUILD_DEBUG_ADAPTER -D_GNU_SOURCE -std=gnu99 -I$STANZADIR/include $STANZADIR/runtime/driver.c $STANZADIR/core/debug/debug-adapter.c $STANZADIR/core/sighandler.c $STANZADIR/runtime/linenoise.c -lm -lpthread -ldl -fPIC -DPLATFORM_LINUX -o debug-adapter
+cp debug-adapter /home/opliss/Work/lbstanza/runtime/debug

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,4 +1,5 @@
 include "examples/stanza.proj"
+include "build-stanza.proj"
 
 package stz/line-noise-prompter requires :
   ccfiles:
@@ -78,4 +79,3 @@ package stz/asmjit requires :
 package stz/macro-plugin requires :
   ccfiles: "compiler/macro-handshake.c"
   ccflags: "-shared"
-


### PR DESCRIPTION
Rename and cherry-pick command-line debugger and debug adapter from oleg/dap.
Add them to stanza build system.
NOTE: Debug adapter implementation modifies runtime/adapter.c to rename `main` entry point to `stanza_main`. At bootstrap STANZA_CONFIG env variable has to be set to use correct version of `adapter.c`.

To build command-line debugger: ./stanza build debugger
To build debug-adapter: ... set STANZA_CONFIG ... ./stanza build debug-adapter

Only Linux and MacOS are supported now.
Only Linux is tested.