### PR TITLE
Add optional doc string for the package definition in defs-db

### DIFF
--- a/compiler/defs-db-ir.stanza
+++ b/compiler/defs-db-ir.stanza
@@ -20,6 +20,7 @@ public defstruct PackageDefinitions :
   source: SrcDefinitionSource
   imports:Tuple<PackageImport>
   definitions:Tuple<Definition>
+  documentation?:False|String
 
 doc: "A single defined item."
 public defstruct Definition <: Equalable : 
@@ -114,6 +115,7 @@ defmethod print (o:OutputStream, defs:PackageDefinitions) :
   val o2 = IndentedStream(o)
   lnprint(o2, "stamp: %_" % [stamp(defs)])
   lnprint(o2, "source: %_" % [source(defs)])
+  lnprint(o2, "documentation?:\n%_" % [Indented(documentation?(defs))])  
   do(lnprint{o2, _}, imports(defs))
   do(lnprint{o2, _}, definitions(defs))
 

--- a/compiler/defs-db-serializer.stanza
+++ b/compiler/defs-db-serializer.stanza
@@ -46,6 +46,7 @@ defserializer DefsDbSerializer () :
     source:src-def-src
     imports:tuple(package-import)
     definitions:tuple(definition)
+    documentation?:opt(string)
 
   deftype unresolved-symbol (UnresolvedSymbol) :
     symbol:symbol

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -159,7 +159,8 @@ defn build-package-defs (pkg:Pkg, stamp:PackageStamp, nm:NameMap) -> PackageDefi
                      stamp,
                      PkgDefinition,
                      [],
-                     definitions)
+                     definitions,
+                     documentation?(packageio))
 
 ;------------------------------------------------------------
 ;---------- PackageDefinitions for IPackage -----------------
@@ -187,13 +188,17 @@ protected-when(TESTING) defn build-package-defs (ipackage:IPackage,
         val annotation? = annotation?(indexed)
         val documentation? = documentation?(indexed)
 
+  val doc? = match(documentation?(ipackage)):
+    (x:IDoc) : value(string(x) as ILiteral) as String
+    (_) : false
 
   ;Bundle results in PackageDefinitions structure.
   PackageDefinitions(name(ipackage),
                      stamp,
                      SrcDefinition,
                      map(to-package-import, imports(ipackage)),
-                     definitions)
+                     definitions,
+                     doc?)
 
 ; Depth first walk of the IL-IR to flatten into a sequence of `Indexed`, or
 ; IExp nodes that have a meaningful name and FileInfo


### PR DESCRIPTION
This commit adds a `documentation?` string to the `PackageDefinitions` object so that when the definitions are dumped, the package doc string is accessible. This will make it easier to write documentation for a package inline with the code and have this content extracted to language servers, autodoc, etc.

I've built and tested this locally with some autodoc tooling and it successfully creates the docstring and handles the case where there is no docstring with `false`. 