### PR TITLE
Added optional, keyword, and variadic meta-data to defs-db

### DIFF
--- a/compiler/defs-db-ir.stanza
+++ b/compiler/defs-db-ir.stanza
@@ -61,6 +61,9 @@ doc: "A single function argument."
 public defstruct FnArgAnnotation <: Equalable :
   name?:Symbol|False
   type?:Symbol|False
+  keyword?:True|False
+  variadic?:True|False
+  optional?:True|False
 
 doc: "An imported package and its prefixes."
 public defstruct PackageImport : 
@@ -97,7 +100,10 @@ defmethod equal? (l:DefnAnnotation, r:DefnAnnotation) :
 
 defmethod equal? (l:FnArgAnnotation, r:FnArgAnnotation) : 
   name?(l) == name?(r) and 
-  type?(l) == type?(r)
+  type?(l) == type?(r) and
+  keyword?(l) == keyword?(r) and
+  variadic?(l) == variadic?(r) and
+  optional?(l) == optional?(r)
 
 ;===============================================================================
 ;============================== Printers =======================================
@@ -133,11 +139,23 @@ defmethod print (o:OutputStream, a:FnArgAnnotation) :
     (n:False,  t:Symbol) : print(o, "_:%_" % [t])
     (n:Symbol, t:Symbol) : print(o, "%_:%_" % [n, t])
     (n:False,  t:False)  : print(o, "?")
-  
+  if optional?(a):
+    print(o, " = ?")
+  if variadic?(a):
+    print(o, " ...")
+
 defmethod print (o:OutputStream, f:DefnAnnotation) : 
   if not empty?(targs(f)) : 
     print(o, "<%,>" % [targs(f)])
-  print(o, "(%,)" % [args(f)])
+  ; Split on keyword/non-keyword
+  val grps = map(to-tuple, split(keyword?, args(f)))
+  val kwArgs = grps[0]
+  val posArgs = grps[1]
+  print(o, "(%," % [posArgs])
+  if length(kwArgs) > 0:
+    print(o, " -- %,)" % [kwArgs])
+  else:
+    print(o, ")")
   val return-type? = return-type?(f)
   match(return-type?:Symbol) : 
     print(o, " -> %_" % [return-type?])

--- a/compiler/defs-db-serializer.stanza
+++ b/compiler/defs-db-serializer.stanza
@@ -90,6 +90,9 @@ defserializer DefsDbSerializer () :
   deftype fn-arg-annotation (FnArgAnnotation) : 
     name?:opt(symbol)
     type?:opt(symbol)
+    keyword?:bool
+    variadic?:bool
+    optional?:bool
   
   defunion annotation (DefinitionAnnotation) : 
     DefnAnnotation : 

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -279,6 +279,18 @@ protected-when(TESTING) defn index-expressions (exps:List<IExp>, nm:NameMap) -> 
 ;------------- Computing Definition Annotations -------------
 ;------------------------------------------------------------
 
+defn is-keyword (arg:IExp) -> True|False :
+  match(arg:IKeyword|IOptionalKeyword): true
+  else: false
+
+defn is-optional (arg:IExp) -> True|False :
+  match(arg:IOptional|IOptionalKeyword): true
+  else: false
+
+defn is-variadic (arg:IExp) -> True|False :
+  match(arg:IRest): true
+  else: false
+
 ;Create an annotation for a top-level expression.
 defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
   match(iexp) :
@@ -290,11 +302,29 @@ defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
             stringify?(arg, nm) as Symbol
         val args = to-tuple $
           for (arg in args(idefn), type in a1(idefn)) seq :
-            val arg-name = stringify?(arg, nm)
             val type-name = stringify?(type, nm)
-            FnArgAnnotation(arg-name, type-name)
+            val arg-name = stringify?(arg, nm)
+            FnArgAnnotation(
+              arg-name, type-name,
+              is-keyword(arg),
+              is-variadic(arg),
+              is-optional(arg))
     (iexp) :
       false
+
+defn is-keyword (arg:FArg<DType>) -> True|False :
+  match(arg:KeywordArg<DType>): true
+  else: false
+
+defn is-variadic (arg:FArg<DType>) -> True|False :
+  match(arg:VarArg<DType>): true
+  else: false
+
+defn is-optional (arg:FArg<DType>) -> True|False :
+  match(arg):
+    (arg:KeywordArg<DType>): optional?(arg)
+    (arg:PositionalArg<DType>): optional?(arg)
+    (_): false
 
 ;Create an annotation for a PackageIO Export expression.
 defn annotate? (export:Export, nm:NameMap) -> False|DefinitionAnnotation :
@@ -310,8 +340,12 @@ defn annotate? (export:Export, nm:NameMap) -> False|DefinitionAnnotation :
             else :
               to-symbol("?TV%_" % [n])
         val args = to-tuple $
-          for (arg-type in a1(id(rec) as FnId), n in 0 to false) seq :
-            FnArgAnnotation(to-symbol("_%_" % [n]), stringify?(arg-type, nm))
+          for (arg-type in a1(fnid), n in 0 to false) seq :
+            FnArgAnnotation(
+              to-symbol("_%_" % [n]), stringify?(arg-type, nm),
+              is-keyword(arg-type),
+              is-variadic(arg-type),
+              is-optional(arg-type))
     (r:?) :
       false
 


### PR DESCRIPTION
This commit adds support for the optional, keyword, and variadic meta data as it applies to function arguments.

Note that I have not included the `default` value for optional positional or keyword arguments because the expression for default is not easily extracted in the current implementation.

I've tested this with a local harness program. I've listed some of the examples below. What I have not been able to successfully test is the extraction from the `*.pkg` file to definitions database. Do you have a suggestion for how to test that ? 

## Positional Argument with Default

This Stanza Function:
```
doc: \<DOC>
  @brief Function with a positional with default
  @param a this is an arg with a default value.
  @return Lucky Number
<DOC>
public defn default_arg_func (a:String = "asdf") :
  1
```

Results

```
Definition default_arg_func defined at /Users/callendorph/src/build_lbstanza/root/basic/optargs.stanza:9.12:
    kind: SrcDefFunction
    visibility: Public
    annotation?: (a:String = ?)
    documentation?:

        @brief Function with a positional with default
        @param a this is an arg with a default value.
        @return Lucky Number
```

## Keyword Argument

```
doc: \<DOC>
  @brief Function with keyword argument
  @param a this is an arg
  @param quiet this is not an arg but a keyword arg
  @return Probability of success
<DOC>
public defn keyword_args_func (a:Int -- quiet:True|False) -> Double :
  1.0
```

Output:
```
  Definition keyword_args_func defined at /Users/callendorph/src/build_lbstanza/root/basic/optargs.stanza:18.12:
    kind: SrcDefFunction
    visibility: Public
    annotation?: (a:Int -- quiet:True|False) -> Double
    documentation?:

        @brief Function with keyword argument
        @param a this is an arg
        @param quiet this is not an arg but a keyword arg
        @return Probability of success
```

## Optional Keyword

```
doc: \<DOC>
  @brief Function with an optional keyword argument
  @param b this is an arg
  @param quiet this is not an arg but a keyword arg with a default.
  @return Message of the day
<DOC>
public defn optional_kw_func (b:Int -- quiet:True|False = false) -> String :
  "asdf"
```

```
 Definition optional_kw_func defined at /Users/callendorph/src/build_lbstanza/root/basic/optargs.stanza:27.12:
    kind: SrcDefFunction
    visibility: Public
    annotation?: (b:Int -- quiet:True|False = ?) -> String
    documentation?:

        @brief Function with an optional keyword argument
        @param b this is an arg
        @param quiet this is not an arg but a keyword arg with a default.
        @return Message of the day

```

## Variadic Function Argument

```
doc: \<DOC>
  @brief Function with variadic args
  @param a this is an arg
  @param b this is tuple of strings
  @return Number of steaks I ate for breakfast
<DOC>
public defn variadic_func (a:Int, b:String ...) -> Int :
  1
```

```
 Definition variadic_func defined at /Users/callendorph/src/build_lbstanza/root/basic/optargs.stanza:36.12:
    kind: SrcDefFunction
    visibility: Public
    annotation?: (a:Int, b:String ...) -> Int
    documentation?:

        @brief Function with variadic args
        @param a this is an arg
        @param b this is tuple of strings
        @return Number of steaks I ate for breakfast

```