### PR TITLE
Version 0.18.44: default pkg cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 *.exe
 stanza.aux
 stanza
+repl-history.txt

--- a/compiler/auto-doc.stanza
+++ b/compiler/auto-doc.stanza
@@ -587,7 +587,7 @@ defn match-package-pathnames (ipackages:Seqable<IPackage>, pkg-filter-filename:F
 ;  toc-renamer-filename: "pathnames" to use for TOC
 ;  trace?:               trace pattern expression evaluation?
 public defn auto-doc (settings:BuildSettings, output:String, pkg-filter-filename:False|String, fig-filter-filename:False|String, toc-renamer-filename:False|String, trace?:True|False) :
-  val dep-result = dependencies(settings, true)
+  val dep-result = dependencies(settings)
   throw-errors(dep-result)
   val dir = match(output:String): output else: "docs"
   gen-doc(dir, namemap(dep-result),

--- a/compiler/compiler-build-settings.stanza
+++ b/compiler/compiler-build-settings.stanza
@@ -17,7 +17,7 @@ public defstruct BuildSettings :
   external-dependencies: String|False
   pkg-dir: String|False
   pkg-cache-dir: String|False with: (updater => sub-pkg-cache-dir)
-  ignore-cache?: True|False
+  disable-cache?: True|False
   optimize?: True|False
   debug?: True|False
   ccfiles: Tuple<String>

--- a/compiler/compiler-build-settings.stanza
+++ b/compiler/compiler-build-settings.stanza
@@ -17,6 +17,7 @@ public defstruct BuildSettings :
   external-dependencies: String|False
   pkg-dir: String|False
   pkg-cache-dir: String|False with: (updater => sub-pkg-cache-dir)
+  ignore-cache?: True|False
   optimize?: True|False
   debug?: True|False
   ccfiles: Tuple<String>

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -182,13 +182,15 @@ public defn compile (proj-manager:ProjManager,
 
     ;Create pkg saver for saving output .pgk files.
     val cache-dir = pkg-cache-dir(proj-manager)
+    val ignore-cache? = ignore-cache?(proj-manager)
     val pkgsaver = PkgSaver(auxfile,
                             pkgstamps(result),
                             pkg-dir,
                             flags,
                             debug?,
                             false,
-                            cache-dir)
+                            cache-dir,
+                            ignore-cache?)
     
     ;True if pkgs are written out, either to the pkg directory
     ;or to the cache directory.

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -182,15 +182,13 @@ public defn compile (proj-manager:ProjManager,
 
     ;Create pkg saver for saving output .pgk files.
     val cache-dir = pkg-cache-dir(proj-manager)
-    val ignore-cache? = ignore-cache?(proj-manager)
     val pkgsaver = PkgSaver(auxfile,
                             pkgstamps(result),
                             pkg-dir,
                             flags,
                             debug?,
                             false,
-                            cache-dir,
-                            ignore-cache?)
+                            cache-dir)
     
     ;True if pkgs are written out, either to the pkg directory
     ;or to the cache directory.

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -106,7 +106,7 @@ defn compute-build-settings (projenv:StandardProjEnv,
         build-ext-deps,
         build-pkg-dir,
         pkg-cache-dir*,
-        ignore-cache?(settings)
+        disable-cache?(settings)
         build-optimization,
         build-debug,
         build-ccfiles,
@@ -243,7 +243,7 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       println("Build target %~ is already up-to-date." % [build-target?(settings*)])
     else :
       setup-system-flags(settings*)
-      val proj-manager = ProjManager(proj, ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, ignore-cache?(settings)), auxfile)
+      val proj-manager = ProjManager(proj, ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, disable-cache?(settings)), auxfile)
       val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
                                 backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,
                                 macro-plugins(settings*), inputs(settings) is BuildTarget)

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -106,6 +106,7 @@ defn compute-build-settings (projenv:StandardProjEnv,
         build-ext-deps,
         build-pkg-dir,
         pkg-cache-dir*,
+        ignore-cache?(settings)
         build-optimization,
         build-debug,
         build-ccfiles,
@@ -186,7 +187,7 @@ public defn dependencies (settings:BuildSettings, ignore-cache?:True|False) -> D
       (f:False) : OUTPUT-PLATFORM
 
   defn compute-dependencies (proj:ProjFile, settings:BuildSettings) :
-    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false)
+    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false, false)
     val auxfile = AuxFile() when not ignore-cache?
     val proj-manager = ProjManager(proj, params, auxfile)
     val macroexpander = StanzaMacroexpander(false, proj-manager, macro-plugins(settings))
@@ -242,7 +243,7 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       println("Build target %~ is already up-to-date." % [build-target?(settings*)])
     else :
       setup-system-flags(settings*)
-      val proj-manager = ProjManager(proj, ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false), auxfile)
+      val proj-manager = ProjManager(proj, ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, ignore-cache?(settings)), auxfile)
       val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
                                 backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,
                                 macro-plugins(settings*), inputs(settings) is BuildTarget)

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -95,7 +95,7 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false,                                  ;external dependencies
     false,                                  ;pkg-dir
     false,                                  ;pkg-cache-dir
-    false,                                  ;ignore-cache?
+    false,                                  ;disable-cache?
     optimize?(input),                       ;optimize?
     false,                                  ;debug?
     [],                                     ;ccfiles

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -95,6 +95,7 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false,                                  ;external dependencies
     false,                                  ;pkg-dir
     false,                                  ;pkg-cache-dir
+    false,                                  ;ignore-cache?
     optimize?(input),                       ;optimize?
     false,                                  ;debug?
     [],                                     ;ccfiles

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -95,7 +95,7 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false,                                  ;external dependencies
     false,                                  ;pkg-dir
     false,                                  ;pkg-cache-dir
-    false,                                  ;disable-cache?
+    true,                                   ;disable-cache?
     optimize?(input),                       ;optimize?
     false,                                  ;debug?
     [],                                     ;ccfiles
@@ -105,7 +105,7 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false)                                  ;link-type
 
   ;Compute dependencies (compiles to IL-IR)
-  dependencies(build-settings, true)
+  dependencies(build-settings)
 
 ;============================================================
 ;============= Building the Database ========================

--- a/compiler/dependencies.stanza
+++ b/compiler/dependencies.stanza
@@ -15,11 +15,10 @@ defpackage stz/dependencies :
   import stz/compiler-build-settings
   
 public defn analyze-dependencies (settings:BuildSettings,
-                                  ignore-cache?:True|False,
                                   output:String|False,
                                   graphviz:String|False) :
   defn driver () :
-    val dep-result = dependencies(settings, ignore-cache?)
+    val dep-result = dependencies(settings)
     val dependencies = scan-dependencies(packages(dep-result))
     val source-files = SourceFiles $
       for stamp in pkgstamps(dep-result) seq :

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -967,10 +967,9 @@ defn analyze-dependencies-command () :
   between packages."
   defn analyze-dependencies-action (cmd-args:CommandArgs) :
     defn main () :
-      val disable-cache? = flag?(cmd-args, "disable-cache")
       val output = get?(cmd-args, "o", false)
       val graphviz = get?(cmd-args, "graphviz", false)
-      analyze-dependencies(build-settings(), disable-cache?, output, graphviz)
+      analyze-dependencies(build-settings(), output, graphviz)
 
     defn build-settings () :
       defn symbol? (name:String) :
@@ -991,7 +990,7 @@ defn analyze-dependencies-command () :
         false
         pkg-dir
         false
-        false
+        flag?(cmd-args, "disable-cache")
         flag?(cmd-args, "optimize")
         false
         []

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -226,7 +226,7 @@ val COMMON-STANZA-FLAGS = [
     "Requests the compiler to output the .pkg files. The name of the folder to store the output .pkg files can be optionally provided.")
   Flag("pkg-cache", OneFlag, OptionalFlag,
     "Directory for caching compiled .pkg files")
-  Flag("ignore-cache", ZeroFlag, OptionalFlag,
+  Flag("disable-cache", ZeroFlag, OptionalFlag,
     "Ignore .pkg cache")
   Flag("optimize", ZeroFlag, OptionalFlag,
     "Requests the compiler to compile in optimized mode.")
@@ -333,7 +333,7 @@ defn compile-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "ignore-cache")
+        flag?(cmd-args, "disable-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -350,7 +350,7 @@ defn compile-command () :
   ;Command
   Command("compile",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names.",
-          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "ignore-cache" "optimize" "debug" "ccfiles" "ccflags" "flags"
+          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "disable-cache" "optimize" "debug" "ccfiles" "ccflags" "flags"
                                "verbose" "supported-vm-packages" "platform" "external-dependencies" "macros" "link" "timing-log"]),
           compile-msg, false, verify-args, intercept-no-match-exceptions(compile-action))
 
@@ -383,7 +383,7 @@ defn build-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "ignore-cache")
+        flag?(cmd-args, "disable-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         []
@@ -400,7 +400,7 @@ defn build-command () :
   ;Command definition
   Command("build",
           ZeroOrOneArg, "the name of the build target. If not supplied, the default build target is 'main'.",
-          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
+          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
           build-msg, false, verify-args, intercept-no-match-exceptions(build))
 
 ;============================================================
@@ -520,7 +520,7 @@ defn compile-test-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "ignore-cache")
+        flag?(cmd-args, "disable-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -535,7 +535,7 @@ defn compile-test-command () :
   ;Command definition
   Command("compile-test",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing tests.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
                                "macros" "link" "timing-log"])
           compile-test-msg, false, verify-args, intercept-no-match-exceptions(compile-test))
 
@@ -586,7 +586,7 @@ defn compile-macros-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "ignore-cache")
+        flag?(cmd-args, "disable-cache")
         flag?(cmd-args, "optimize")
         false
         get?(cmd-args, "ccfiles", [])
@@ -601,7 +601,7 @@ defn compile-macros-command () :
   ;Command definition
   Command("compile-macros",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing macros.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "ccfiles" "ccflags" "flags" "optimize" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "ccfiles" "ccflags" "flags" "optimize" "verbose"
                                "macros" "timing-log"])
           compile-macros-msg, false, verify-args, intercept-no-match-exceptions(compile-macro))
 
@@ -712,7 +712,7 @@ defn repl-command () :
       "The terminal style (simple/edit) to use for the REPL. If not provided, defaults to 'edit' if available \
        on the current platform.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("ignore-cache")
+    common-stanza-flag("disable-cache")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
     Flag("-", AllRemainingFlag, OptionalFlag,
@@ -765,7 +765,7 @@ defn repl-command () :
              terminal-style,
              get?(cmd-args, "macros", [])
              get?(cmd-args, "pkg-cache", false)
-             flag?(cmd-args, "ignore-cache"))
+             flag?(cmd-args, "disable-cache"))
 
     ;Confirm exit
     if flag?(cmd-args, "confirm-before-exit") :
@@ -801,7 +801,7 @@ defn run-command () :
     Flag("flags", ZeroOrMoreFlag, OptionalFlag,
       "The set of compile-time flags to be set before beginning execution.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("ignore-cache")
+    common-stanza-flag("disable-cache")
     common-stanza-flag("verbose")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
@@ -841,7 +841,7 @@ defn run-command () :
         run-in-repl(args(cmd-args),
                     get?(cmd-args, "macros", []),
                     get?(cmd-args, "pkg-cache", false)
-                    flag?(cmd-args, "ignore-cache"))
+                    flag?(cmd-args, "disable-cache"))
 
   ;Command definition
   Command(
@@ -873,7 +873,7 @@ defn run-test-command () :
     Flag("log", OneFlag, OptionalFlag,
       "The directory to output the test results to.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("ignore-cache")
+    common-stanza-flag("disable-cache")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")]
 
@@ -926,7 +926,7 @@ defn run-test-command () :
       run-in-repl(new-args,
                   get?(cmd-args, "macros", []),
                   get?(cmd-args, "pkg-cache", false),
-                  flag?(cmd-args, "ignore-cache"))
+                  flag?(cmd-args, "disable-cache"))
 
   ;Command definition
   Command("run-test",
@@ -947,7 +947,7 @@ defn analyze-dependencies-command () :
       "If given, outputs the dependencies using the GraphViz format to the given file.")
     Flag("build-target", ZeroFlag, OptionalFlag,
       "If given, then the argument is interpreted to be the name of a build target instead of a Stanza package.")
-    Flag("ignore-cache", ZeroFlag, OptionalFlag,
+    Flag("disable-cache", ZeroFlag, OptionalFlag,
       "If given, then packages will always be loaded from their source files instead of their .pkg files if \
        their source files are available.")
     Flag("pkg", ZeroOrOneFlag, OptionalFlag,
@@ -969,10 +969,10 @@ defn analyze-dependencies-command () :
   between packages."
   defn analyze-dependencies-action (cmd-args:CommandArgs) :
     defn main () :
-      val ignore-cache? = flag?(cmd-args, "ignore-cache")
+      val disable-cache? = flag?(cmd-args, "disable-cache")
       val output = get?(cmd-args, "o", false)
       val graphviz = get?(cmd-args, "graphviz", false)
-      analyze-dependencies(build-settings(), ignore-cache?, output, graphviz)
+      analyze-dependencies(build-settings(), disable-cache?, output, graphviz)
 
     defn build-settings () :
       defn symbol? (name:String) :

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -226,6 +226,8 @@ val COMMON-STANZA-FLAGS = [
     "Requests the compiler to output the .pkg files. The name of the folder to store the output .pkg files can be optionally provided.")
   Flag("pkg-cache", OneFlag, OptionalFlag,
     "Directory for caching compiled .pkg files")
+  Flag("ignore-cache", ZeroFlag, OptionalFlag,
+    "Ignore .pkg cache")
   Flag("optimize", ZeroFlag, OptionalFlag,
     "Requests the compiler to compile in optimized mode.")
   Flag("debug", ZeroFlag, OptionalFlag,
@@ -331,6 +333,7 @@ defn compile-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
+        flag?(cmd-args, "ignore-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -347,7 +350,7 @@ defn compile-command () :
   ;Command
   Command("compile",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names.",
-          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "optimize" "debug" "ccfiles" "ccflags" "flags"
+          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "ignore-cache" "optimize" "debug" "ccfiles" "ccflags" "flags"
                                "verbose" "supported-vm-packages" "platform" "external-dependencies" "macros" "link" "timing-log"]),
           compile-msg, false, verify-args, intercept-no-match-exceptions(compile-action))
 
@@ -380,6 +383,7 @@ defn build-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
+        flag?(cmd-args, "ignore-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         []
@@ -396,7 +400,7 @@ defn build-command () :
   ;Command definition
   Command("build",
           ZeroOrOneArg, "the name of the build target. If not supplied, the default build target is 'main'.",
-          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
+          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
           build-msg, false, verify-args, intercept-no-match-exceptions(build))
 
 ;============================================================
@@ -444,6 +448,7 @@ defn extend-command () :
         AsmFile?(get?(cmd-args, "s", false))
         get?(cmd-args, "o", false)
         get?(cmd-args, "external-dependencies", false)
+        false
         false
         false
         flag?(cmd-args, "optimize")
@@ -515,6 +520,7 @@ defn compile-test-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
+        flag?(cmd-args, "ignore-cache")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -529,7 +535,7 @@ defn compile-test-command () :
   ;Command definition
   Command("compile-test",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing tests.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
                                "macros" "link" "timing-log"])
           compile-test-msg, false, verify-args, intercept-no-match-exceptions(compile-test))
 
@@ -580,6 +586,7 @@ defn compile-macros-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
+        flag?(cmd-args, "ignore-cache")
         flag?(cmd-args, "optimize")
         false
         get?(cmd-args, "ccfiles", [])
@@ -594,7 +601,7 @@ defn compile-macros-command () :
   ;Command definition
   Command("compile-macros",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing macros.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ccfiles" "ccflags" "flags" "optimize" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "ignore-cache" "ccfiles" "ccflags" "flags" "optimize" "verbose"
                                "macros" "timing-log"])
           compile-macros-msg, false, verify-args, intercept-no-match-exceptions(compile-macro))
 
@@ -705,6 +712,7 @@ defn repl-command () :
       "The terminal style (simple/edit) to use for the REPL. If not provided, defaults to 'edit' if available \
        on the current platform.")
     common-stanza-flag("pkg-cache")
+    common-stanza-flag("ignore-cache")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
     Flag("-", AllRemainingFlag, OptionalFlag,
@@ -756,7 +764,8 @@ defn repl-command () :
         repl(args(cmd-args),
              terminal-style,
              get?(cmd-args, "macros", [])
-             get?(cmd-args, "pkg-cache", false))
+             get?(cmd-args, "pkg-cache", false)
+             flag?(cmd-args, "ignore-cache"))
 
     ;Confirm exit
     if flag?(cmd-args, "confirm-before-exit") :
@@ -792,6 +801,7 @@ defn run-command () :
     Flag("flags", ZeroOrMoreFlag, OptionalFlag,
       "The set of compile-time flags to be set before beginning execution.")
     common-stanza-flag("pkg-cache")
+    common-stanza-flag("ignore-cache")
     common-stanza-flag("verbose")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
@@ -830,7 +840,8 @@ defn run-command () :
         ;Run in REPL
         run-in-repl(args(cmd-args),
                     get?(cmd-args, "macros", []),
-                    get?(cmd-args, "pkg-cache", false))
+                    get?(cmd-args, "pkg-cache", false)
+                    flag?(cmd-args, "ignore-cache"))
 
   ;Command definition
   Command(
@@ -862,6 +873,7 @@ defn run-test-command () :
     Flag("log", OneFlag, OptionalFlag,
       "The directory to output the test results to.")
     common-stanza-flag("pkg-cache")
+    common-stanza-flag("ignore-cache")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")]
 
@@ -913,7 +925,8 @@ defn run-test-command () :
       ;Run in REPL
       run-in-repl(new-args,
                   get?(cmd-args, "macros", []),
-                  get?(cmd-args, "pkg-cache", false))
+                  get?(cmd-args, "pkg-cache", false),
+                  flag?(cmd-args, "ignore-cache"))
 
   ;Command definition
   Command("run-test",
@@ -979,6 +992,7 @@ defn analyze-dependencies-command () :
         false
         false
         pkg-dir
+        false
         false
         flag?(cmd-args, "optimize")
         false
@@ -1052,6 +1066,7 @@ defn auto-doc-command () :
         false
         false
         pkg-dir
+        false
         false
         flag?(cmd-args, "optimize")
         false

--- a/compiler/params.stanza
+++ b/compiler/params.stanza
@@ -25,6 +25,7 @@ public var STANZA-PKG-DIRS:List<String> = List()
 public val STANZA-PROJ-FILES = Vector<String>()
 public var EXPERIMENTAL-FEATURES:Tuple<Symbol> = []
 public var AUX-FILE-OVERRIDE:String|False = false
+public var STANZA-CACHE-DIR:String = ".pkg-cache"
 
 ;====== Currently-Supported Experimental Features =====
 public val SUPPORTED-EXPERIMENTAL-FEATURES = `(
@@ -93,6 +94,7 @@ public defenum SystemFile :
   StanzaAuxFile
   StanzaPkgsDir
   StanzaREPLHistory
+  StanzaPkgCacheDir
 
 public defn system-filepath (install-dir:String, file:SystemFile) -> String :
   ;Compute path relative to installation folder.
@@ -113,6 +115,7 @@ public defn system-filepath (install-dir:String, file:SystemFile) -> String :
       match(AUX-FILE-OVERRIDE:String) : AUX-FILE-OVERRIDE
       else : relative-to-install("stanza.aux")
     StanzaPkgsDir : relative-to-install("pkgs")
+    StanzaPkgCacheDir : relative-to-install(".pkg-cache")
     StanzaREPLHistory : relative-to-install("repl-history.txt")
 
 public defn system-filepath (file:SystemFile) -> String :

--- a/compiler/params.stanza
+++ b/compiler/params.stanza
@@ -18,7 +18,7 @@ public defn compiler-flags () :
   to-tuple(COMPILE-FLAGS)
 
 ;========= Stanza Configuration ========
-public val STANZA-VERSION = [0 18 43] 
+public val STANZA-VERSION = [0 18 44] 
 public var STANZA-INSTALL-DIR:String = ""
 public var OUTPUT-PLATFORM:Symbol = `platform
 public var STANZA-PKG-DIRS:List<String> = List()

--- a/compiler/pkg-saver.stanza
+++ b/compiler/pkg-saver.stanza
@@ -45,8 +45,7 @@ public defn PkgSaver (auxfile:AuxFile,
                       flags:Tuple<Symbol>,
                       debug?:True|False,
                       repl?:True|False,
-                      cache-dir:String|False,
-                      ignore-cache?:True|False) :
+                      cache-dir:String|False) :
 
   ;Table of PackageStamps for easy retrieval.
   val pkgstamp-table = to-hashtable(package, package-stamps)

--- a/compiler/pkg-saver.stanza
+++ b/compiler/pkg-saver.stanza
@@ -77,6 +77,11 @@ public defn PkgSaver (auxfile:AuxFile,
   ;of the given package.
   defn origin (pkg:Pkg) -> PackageOrigin :
     /origin(location(pkgstamp-table[name(pkg)]))
+
+  ;Helper: extract source file drom pkgstamp-table
+  ;Precondition: Assumes origin(pkg) == FromSource
+  defn pkg-source (pkg:Pkg) -> String :
+    source-file(location(pkgstamp-table[name(pkg)])) as String
   
   ;Main implementation.
   new PkgSaver :
@@ -94,7 +99,7 @@ public defn PkgSaver (auxfile:AuxFile,
     defmethod cache (this, pkg:Pkg) :
       if origin(pkg) != FromSource :
         fatal("Cannot cache a .pkg that did not originate from source file.")
-      val params = CacheParams(flags, cache-dir as String, repl?, debug?)
+      val params = CacheParams(flags, cache-dir as String, repl?, debug?, pkg-source(pkg))
       val filename = save-package-to-cache(params, pkg)
       val filestamp = filestamp(filename)
       save-aux-record(pkg, filestamp)

--- a/compiler/pkg-saver.stanza
+++ b/compiler/pkg-saver.stanza
@@ -45,7 +45,8 @@ public defn PkgSaver (auxfile:AuxFile,
                       flags:Tuple<Symbol>,
                       debug?:True|False,
                       repl?:True|False,
-                      cache-dir:String|False) :
+                      cache-dir:String|False,
+                      ignore-cache?:True|False) :
 
   ;Table of PackageStamps for easy retrieval.
   val pkgstamp-table = to-hashtable(package, package-stamps)

--- a/compiler/pkg.stanza
+++ b/compiler/pkg.stanza
@@ -51,7 +51,7 @@ public defn save-package (dir:String, p:Pkg) -> String :
 ;Save the given Pkg to the pkg cache with the given caching parameters.
 public defn save-package-to-cache (params:CacheParams, p:Pkg) -> String :
   ;Calculate the filename mode from the given Pkg structure.
-  val mode = CacheFilename(p is FastPkg, flags(params), repl?(params), debug?(params))
+  val mode = CacheFilename(p is FastPkg, flags(params), repl?(params), debug?(params), source-file(params))
   ;Compute the filename.
   val filename = pkg-filename(name(p), mode)
   save-package(p, dir(params), filename)
@@ -153,13 +153,13 @@ public defn find-pkg (name:Symbol,
     match(cache-params:CacheParams) :
     
       ;First check under the given cache mode.
-      val mode = CacheFilename(optimized?, flags(cache-params), repl?(cache-params), debug?(cache-params))
+      val mode = CacheFilename(optimized?, flags(cache-params), repl?(cache-params), debug?(cache-params), source-file(cache-params))
       check-dir(dir(cache-params), mode, PkgCache)
 
       ;Then specifically if it is for the REPL, additionally check the
       ;non-repl version since it can also be used.
       if repl?(cache-params) :
-        val non-repl-mode = CacheFilename(optimized?, flags(cache-params), false, debug?(cache-params))
+        val non-repl-mode = CacheFilename(optimized?, flags(cache-params), false, debug?(cache-params), source-file(cache-params))
         check-dir(dir(cache-params), non-repl-mode, PkgCache)
       
     ;Then check the normal folders.
@@ -180,6 +180,7 @@ public defstruct CacheParams:
   dir:String
   repl?:True|False
   debug?:True|False
+  source-file:String
 
 ;============================================================
 ;===================== Pkg FileNames ========================
@@ -210,6 +211,7 @@ public defstruct CacheFilename <: FilenameMode :
   flags:Tuple<Symbol>
   repl?:True|False
   debug?:True|False
+  source-file:String
 with:
   printer => true
   constructor => #CacheFilename
@@ -218,8 +220,9 @@ with:
 public defn CacheFilename (optimized?:True|False,
                            flags:Tuple<Symbol>,
                            repl?:True|False,
-                           debug?:True|False) -> CacheFilename :
-  #CacheFilename(optimized?, qsort(to-string, flags), repl?, debug?)
+                           debug?:True|False
+                           source-file:String) -> CacheFilename :
+  #CacheFilename(optimized?, qsort(to-string, flags), repl?, debug?, source-file)
 
 ;Return the on-disk name of the .pkg file.
 public defn pkg-filename (name:Symbol,
@@ -247,6 +250,7 @@ defn hash-string (mode:CacheFilename) -> String :
     print(buffer, "[REPL]")
   if debug?(mode) :
     print(buffer, "[DEBUG]")
+  print(buffer, source-file(mode))
   buffer $> to-bytearray
          $> sha256-hash
          $> to-hex

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -84,6 +84,9 @@ public defmulti dynamic-libraries (l:ProjManager, packages:Tuple<Symbol>) -> Req
 ;Return the pkg cache directory if one is supplied.
 public defmulti pkg-cache-dir (l:ProjManager) -> String|False
 
+;Should pkg saver ignore the cache directory?
+public defmulti ignore-cache? (l:ProjManager) -> True|False
+
 ;Represents the required libraries and folders for a set of Stanza packages.
 public defstruct RequiredLibraries :
   packages: Tuple<KeyValue<Symbol,Tuple<String>>>
@@ -137,6 +140,8 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
 
   ;Retrieve the pkg cache directory.
   val pkg-cache-dir = pkg-cache-dir(proj)
+
+  val ignore-cache? = ignore-cache?(params)
 
   ;Find the source file that contains the package.
   defn source-file? (name:Symbol) -> String|False :
@@ -263,6 +268,8 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
     defmethod pkg-cache-dir (this) :
       pkg-cache-dir
 
+    defmethod ignore-cache? (this) : ignore-cache?
+
 ;============================================================
 ;===================== Structures ===========================
 ;============================================================
@@ -272,6 +279,7 @@ public defstruct ProjParams :
   optimize?: True|False
   debug?: True|False
   in-repl?: True|False
+  ignore-cache? : True|False
 
 ;============================================================
 ;===================== Package Tree =========================

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -11,6 +11,7 @@ defpackage stz/proj-manager :
   import stz/package-stamps
   import stz/file-stamps
   import stz/verbose
+  import stz/params
 
 ;<doc>=======================================================
 ;=================== Project Manager ========================
@@ -84,9 +85,6 @@ public defmulti dynamic-libraries (l:ProjManager, packages:Tuple<Symbol>) -> Req
 ;Return the pkg cache directory if one is supplied.
 public defmulti pkg-cache-dir (l:ProjManager) -> String|False
 
-;Should pkg saver ignore the cache directory?
-public defmulti ignore-cache? (l:ProjManager) -> True|False
-
 ;Represents the required libraries and folders for a set of Stanza packages.
 public defstruct RequiredLibraries :
   packages: Tuple<KeyValue<Symbol,Tuple<String>>>
@@ -139,9 +137,11 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
       else : One(package(req) => dylibs(req))
 
   ;Retrieve the pkg cache directory.
-  val pkg-cache-dir = pkg-cache-dir(proj)
-
-  val ignore-cache? = ignore-cache?(params)
+  val pkg-cache-dir = 
+    if ignore-cache?(params) : false
+    else :
+      match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj)
+      else : system-filepath(StanzaPkgCacheDir) 
 
   ;Find the source file that contains the package.
   defn source-file? (name:Symbol) -> String|False :
@@ -267,8 +267,6 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
 
     defmethod pkg-cache-dir (this) :
       pkg-cache-dir
-
-    defmethod ignore-cache? (this) : ignore-cache?
 
 ;============================================================
 ;===================== Structures ===========================

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -168,7 +168,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
     ;Note: If there is no source file present, then we skip looking in the cache
     ;entirely.
     val cache-params = match(pkg-cache-dir:String, src-path:String) :
-      CacheParams(flags(params), pkg-cache-dir, in-repl?(params), debug?(params))
+      CacheParams(flags(params), pkg-cache-dir, in-repl?(params), debug?(params), src-path)
     val pkg-file = find-pkg(name, optimize?(params),
                             cache-params = cache-params)
 

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -138,7 +138,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile|False
 
   ;Retrieve the pkg cache directory.
   val pkg-cache-dir = 
-    if ignore-cache?(params) : false
+    if disable-cache?(params) : false
     else :
       match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj)
       else : system-filepath(StanzaPkgCacheDir) 
@@ -277,7 +277,7 @@ public defstruct ProjParams :
   optimize?: True|False
   debug?: True|False
   in-repl?: True|False
-  ignore-cache? : True|False
+  disable-cache? : True|False
 
 ;============================================================
 ;===================== Package Tree =========================

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -486,8 +486,7 @@ public defn REPL (macro-plugins:Tuple<String>,
                               compiler-flags,
                               false,
                               true,
-                              cache-dir,
-                              ignore-cache?)
+                              cache-dir)
 
       ;Compile the EPackages into VMPackages.
       val vmpackages = for p in packages(result) map :

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -281,7 +281,7 @@ defmulti shutdown (repl:REPL) -> False
 
 public defn REPL (macro-plugins:Tuple<String>,
                   pkg-cache-dir:String|False,
-                  ignore-cache?:True|False) :
+                  disable-cache?:True|False) :
   ;============================================================
   ;===================== REPL State ===========================
   ;============================================================
@@ -309,7 +309,7 @@ public defn REPL (macro-plugins:Tuple<String>,
   defn proj-manager () :
     within log-time(REPL-PROJ-MANAGER) :
       val proj = read-proj-files(proj-files, OUTPUT-PLATFORM, `dynamic, StandardProjEnv())
-      val params = ProjParams(compiler-flags, false, false, true, ignore-cache?)
+      val params = ProjParams(compiler-flags, false, false, true, disable-cache?)
       ProjManager(proj, params, auxfile)
 
   add-all(proj-files, default-proj-files())
@@ -1008,8 +1008,8 @@ public defn repl (args:Tuple<String>,
                   style:TerminalStyle,
                   macro-plugins:Tuple<String>,
                   pkg-cache-dir:String|False,
-                  ignore-cache?:True|False) :
-  val repl = REPL(macro-plugins, pkg-cache-dir, ignore-cache?)
+                  disable-cache?:True|False) :
+  val repl = REPL(macro-plugins, pkg-cache-dir, disable-cache?)
 
   ;Create a LoadExp expression out of the command line
   ;arguments. And execute them in the REPL.
@@ -1069,9 +1069,9 @@ public defn repl () :
 public defn run-in-repl (args:Tuple<String>,
                          macro-plugins:Tuple<String>,
                          pkg-cache-dir:String|False,
-                         ignore-cache?:True|False) :
+                         disable-cache?:True|False) :
   val repl = within log-time(REPL-CREATION) :
-    REPL(macro-plugins, pkg-cache-dir, ignore-cache?)
+    REPL(macro-plugins, pkg-cache-dir, disable-cache?)
   try:
     within log-time(REPL-EXP-EVALUATION) :
       eval-exp(repl, make-load-exp(args, false))

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -280,7 +280,8 @@ defmulti use-syntax (repl:REPL, inputs:Tuple<Symbol>, add-to-existing?:True|Fals
 defmulti shutdown (repl:REPL) -> False
 
 public defn REPL (macro-plugins:Tuple<String>,
-                  pkg-cache-dir:String|False) :
+                  pkg-cache-dir:String|False,
+                  ignore-cache?:True|False) :
   ;============================================================
   ;===================== REPL State ===========================
   ;============================================================
@@ -308,7 +309,7 @@ public defn REPL (macro-plugins:Tuple<String>,
   defn proj-manager () :
     within log-time(REPL-PROJ-MANAGER) :
       val proj = read-proj-files(proj-files, OUTPUT-PLATFORM, `dynamic, StandardProjEnv())
-      val params = ProjParams(compiler-flags, false, false, true)
+      val params = ProjParams(compiler-flags, false, false, true, ignore-cache?)
       ProjManager(proj, params, auxfile)
 
   add-all(proj-files, default-proj-files())
@@ -485,7 +486,8 @@ public defn REPL (macro-plugins:Tuple<String>,
                               compiler-flags,
                               false,
                               true,
-                              cache-dir)
+                              cache-dir,
+                              ignore-cache?)
 
       ;Compile the EPackages into VMPackages.
       val vmpackages = for p in packages(result) map :
@@ -1006,8 +1008,9 @@ defn run-script (repl:REPL, s:String) :
 public defn repl (args:Tuple<String>,
                   style:TerminalStyle,
                   macro-plugins:Tuple<String>,
-                  pkg-cache-dir:String|False) :
-  val repl = REPL(macro-plugins, pkg-cache-dir)
+                  pkg-cache-dir:String|False,
+                  ignore-cache?:True|False) :
+  val repl = REPL(macro-plugins, pkg-cache-dir, ignore-cache?)
 
   ;Create a LoadExp expression out of the command line
   ;arguments. And execute them in the REPL.
@@ -1052,11 +1055,11 @@ public defn repl (args:Tuple<String>,
 ;Default pkg-cache-dir is false.
 
 public defn repl (style:TerminalStyle) :
-  repl([], style, [], false)
+  repl([], style, [], false, false)
 public defn repl (args:Tuple<String>) :
-  repl(args, default-terminal-style(), [], false)
+  repl(args, default-terminal-style(), [], false, false)
 public defn repl () :
-  repl([], default-terminal-style(), [], false)
+  repl([], default-terminal-style(), [], false, false)
 
 ;============================================================
 ;==================== Run Immediately =======================
@@ -1066,9 +1069,10 @@ public defn repl () :
 ;machine. Implements the 'stanza run' command.
 public defn run-in-repl (args:Tuple<String>,
                          macro-plugins:Tuple<String>,
-                         pkg-cache-dir:String|False) :
+                         pkg-cache-dir:String|False,
+                         ignore-cache?:True|False) :
   val repl = within log-time(REPL-CREATION) :
-    REPL(macro-plugins, pkg-cache-dir)
+    REPL(macro-plugins, pkg-cache-dir, ignore-cache?)
   try:
     within log-time(REPL-EXP-EVALUATION) :
       eval-exp(repl, make-load-exp(args, false))


### PR DESCRIPTION
Merge @tjknoth implementation of a default pkg cache directory in the Stanza installation directory. If nothing else is configured, source code will automatically be cached by this directory.