### PR TITLE
Added `defmulti` to list of functions that get annotated in defs-db

### DIFF
--- a/compiler/defs-db-ir.stanza
+++ b/compiler/defs-db-ir.stanza
@@ -151,7 +151,7 @@ defmethod print (o:OutputStream, f:DefnAnnotation) :
   val grps = map(to-tuple, split(keyword?, args(f)))
   val kwArgs = grps[0]
   val posArgs = grps[1]
-  print(o, "(%," % [posArgs])
+  print(o, " (%," % [posArgs])
   if length(kwArgs) > 0:
     print(o, " -- %,)" % [kwArgs])
   else:

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -323,7 +323,7 @@ defn optional-arg? (arg:FArg<DType>) -> True|False :
 ;Create an annotation for a top-level expression.
 defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
   match(iexp) :
-    (idefn:IDefn|IDefmethod|ILSDefn|ILSDefmethod) :
+    (idefn:IDefn|IDefmethod|IDefmulti|ILSDefn|ILSDefmethod) :
       DefnAnnotation(targs, args, return-type?) where :
         val return-type? = stringify?(a2(idefn), nm)
         val targs = to-tuple $


### PR DESCRIPTION
This commit causes the definitions database to create `SrcDefMulti` kinds of definitions. This means that the `defmulti` declarations for a particular `deftype` will be present in a generated definitions database.

This should help when defining the documentation for a `deftype` interface as the documentation generator will be able to determine what interface defmulti's will apply.

This only seems to be applicable to the definitions created from the source files. Correct me if I'm wrong, but it seems like the `*.pkg` definitions already extract the `MultiRec` which seems to be `defmulti`.

I've tested this locally with the documentation generator and I see the following definitions created:

```
  Definition ESeries defined at /Users/callendorph/src/docgen/test/data/basic/src/deftype.stanza:102.15:
    kind: SrcDefType
    visibility: Public
    annotation?: false
    documentation?:

      E-series Preferred Numbers Base Type
      @see https://en.wikipedia.org/wiki/E_series_of_preferred_numbers

  Definition name defined at /Users/callendorph/src/docgen/test/data/basic/src/deftype.stanza:108.16:
    kind: SrcDefMulti
    visibility: Public
    annotation?: (self:ESeries) -> String
    documentation?:

      Get the Name fo the Series
      @return Series Name in form "E?" where ? is 12, 24, 48, etc

  Definition elements defined at /Users/callendorph/src/docgen/test/data/basic/src/deftype.stanza:113.16:
    kind: SrcDefMulti
    visibility: Public
    annotation?: (self:ESeries) -> Int
    documentation?:

      Get the total number of elements in this series.
      @return Total Number of Series Elements

```

Which matches with the input stanza:

```
doc: \<DOC>
E-series Preferred Numbers Base Type
@see https://en.wikipedia.org/wiki/E_series_of_preferred_numbers
<DOC>
public deftype ESeries

doc: \<DOC>
Get the Name fo the Series
@return Series Name in form "E?" where ? is 12, 24, 48, etc
<DOC>
public defmulti name (self:ESeries) -> String
doc: \<DOC>
Get the total number of elements in this series.
@return Total Number of Series Elements
<DOC>
public defmulti elements (self:ESeries) -> Int
```