### PR TITLE
Add `#env-var` macro for compile time definitions

### DIFF
--- a/compiler/core-macros.stanza
+++ b/compiler/core-macros.stanza
@@ -2369,6 +2369,16 @@ defsyntax core :
 
    defrule id != (~ #if-defined | ~ #if-not-defined)
 
+   ;                       #env-var
+   ;                       ========
+   defrule exp4 = (~ #env-var(?name:#id$)) :
+     get-env(to-string(unwrap-token(name)))
+
+   fail-if exp4 = (~ #env-var) :
+      CSE(closest-info(), "Incorrect syntax for #env-var. Example: '#env-var(PATH)'")
+
+   defrule id != (~ #env-var )
+
    ;                      Quasiquote
    ;                      ==========
    defrule exp4 = (qquote(?sexp ...)) :


### PR DESCRIPTION
This commit adds a new macro definition for accessing environment variables defined during the compilation process.

For example - if you wanted to pass the VERSION info into the build without hard coding it in the code, you could:

```
VERSION="1.2.3" stanza build
```

In your stanza code:

```
val version = #env-var(VERSION)
```

I've attempted to keep the syntax similar to the `#define`, `#if-defined` etc macros by using ids as the argument. There is probably an argument for allowing this to take an expression but I was worried about the side-effects of evaluating an expression during compilation. Let me know what you think.

I've tested this in OS-X for both the happy path and the two syntax error paths (`#env-var` and `#env-var()`) which successfully throw syntax errors. 