### PR TITLE
Added `IDefVar` to list of indexable definitions for defs db

### DIFF
--- a/compiler/defs-db-ir.stanza
+++ b/compiler/defs-db-ir.stanza
@@ -51,6 +51,10 @@ doc: "A DefinitionAnnotation is some definition-specific \
       function signatures."
 public deftype DefinitionAnnotation <: Equalable
 
+doc: "Annotations for `var` and `val` definitions"
+public defstruct DefVarAnnotation <: DefinitionAnnotation :
+  mutable?: True|False
+
 doc: "Annotations given to defn objects."
 public defstruct DefnAnnotation <: DefinitionAnnotation :
   targs:Tuple<Symbol>,

--- a/compiler/defs-db-serializer.stanza
+++ b/compiler/defs-db-serializer.stanza
@@ -99,6 +99,8 @@ defserializer DefsDbSerializer () :
       targs:tuple(symbol), 
       args:tuple(fn-arg-annotation)
       return-type?:opt(symbol)
+    DefVarAnnotation :
+      mutable?:bool
 
   defunion visibility (Visibility) :
     Private: enum

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -323,6 +323,8 @@ defn optional-arg? (arg:FArg<DType>) -> True|False :
 ;Create an annotation for a top-level expression.
 defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
   match(iexp) :
+    (idefvar:IDefVar) : DefVarAnnotation(true)
+    (idefval:IDef) : DefVarAnnotation(false)
     (idefn:IDefn|IDefmethod|IDefmulti|ILSDefn|ILSDefmethod) :
       DefnAnnotation(targs, args, return-type?) where :
         val return-type? = stringify?(a2(idefn), nm)
@@ -344,6 +346,8 @@ defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
 ;Create an annotation for a PackageIO Export expression.
 defn annotate? (export:Export, nm:NameMap) -> False|DefinitionAnnotation :
   match(rec(export)) :
+    (v:ValRec) : DefVarAnnotation(mutable?(v))
+    (v:ExternRec) : DefVarAnnotation(false)
     (rec:FnRec|MultiRec) :
       DefnAnnotation(targs, args, return-type?) where :
         val fnid = id(rec) as FnId
@@ -414,6 +418,7 @@ public defn kindof (r:Rec) -> SrcDefinitionKind :
 deftype Indexable :
   VarN         <: Indexable
   IDef         <: Indexable
+  IDefVar      <: Indexable
   IDefn        <: Indexable
   IDefmulti    <: Indexable
   IDefmethod   <: Indexable


### PR DESCRIPTION
Previously we just had `IDef` which meant that `val` statements would export but `var` statements would not.

I've added `IDefVar` to `Indexable` and I've also created a new `DefinitionAnnotation` for `SrcDefVariable` so that we can differentiate between `val` (immutable) and `var` (mutable).

I've tested this locally on OS-X and was able to get both `val` and `var` definitions as well as the `mutable?` flag giving the right value. 