### PR TITLE
JIT dispatch code instead of trie-tables computing index

### DIFF
--- a/compiler/branch-table.stanza
+++ b/compiler/branch-table.stanza
@@ -13,7 +13,12 @@ defpackage stz/branch-table :
   import stz/set-utils
   import stz/conversion-utils
   import stz/timing-log-api
-
+  import stz/asmjit
+  import stz/jit-encoder
+  import stz/code-table
+  import clib
+  import stz/backend
+  
 ;============================================================
 ;=================== Public Interface =======================
 ;============================================================
@@ -21,7 +26,9 @@ public deftype BranchTable
 public defmulti add (t:BranchTable, f:BranchFormat) -> Int
 public defmulti get (t:BranchTable, f:Int) -> BranchFormat
 public defmulti load-package-methods (t:BranchTable, package:Symbol, ms:Seqable<VMMethod>) -> False
-public defmulti update (t:BranchTable) -> False
+public defmulti update (t:BranchTable, resolver:EncodingResolver) -> False
+public defmulti dispatchers (t:BranchTable) -> FuncBuffer
+public defmulti runtime (t:BranchTable) -> False|JitRuntime
 
 ;============================================================
 ;======================== Timers ============================
@@ -95,18 +102,26 @@ defmethod equal? (a:MultiFormat, b:MultiFormat) :
 ;================= Table Implementation =====================
 ;============================================================
 
-public defn BranchTable (ct:ClassTable) :
+deftype BranchEntries
+defmulti remove (entries:BranchEntries, i:Int) -> False
+defmulti compute (entries:BranchEntries, ct:ClassTable, , resolver:EncodingResolver, backend:Backend, i:Int, f:BranchFormat) -> False
+defmulti key? (entries:BranchEntries, i:Int) -> True|False
+
+public defn BranchTable (ct:ClassTable, jit?:True|False, backend:Backend) :
   ;==================================================
   ;=============== State of Table ===================
   ;==================================================
   ;Store formats in ctable
+  val rt = jit-runtime-new()
+  val func-entries = FuncBranchEntries(FuncBuffer(rt, 8), rt)
+  val trie-entries = TrieBranchEntries(PtrBuffer(8))
+  val entries = func-entries when jit? else trie-entries
   val formats = Vector<BranchFormat>()
   val format-table = HashTable<BranchFormat,Int>()
   val methods = Vector<LoadedMethod|False>()
 
   ;All compiled tables corresponding to each format
-  val trie-table = PtrBuffer(8)
-  val stale-trie-tables = Vector<Int>()
+  val stale-entries = Vector<Int>()
 
   ;Format dependencies
   val format-class-dependencies = DynBiTable()
@@ -115,35 +130,35 @@ public defn BranchTable (ct:ClassTable) :
   val method-multi-table = DynBiTable() ;Mapping from method to multis
 
   ;==================================================
-  ;============= Trie Table Invalidation ============
+  ;================ Entry Invalidation ==============
   ;==================================================
   ;Record a table as invalidated, so that it is updated next cycle.
-  defn invalidate-table (i:Int) :
-    remove(trie-table, i)
-    add(stale-trie-tables, i)
+  defn invalidate-entry (i:Int) :
+    remove(entries, i)
+    add(stale-entries, i)
 
-  defn invalidate-tables-of-multi (multi:Int) :
-    do(invalidate-table, multi-formats[multi])
+  defn invalidate-entries-of-multi (multi:Int) :
+    do(invalidate-entry, multi-formats[multi])
 
-  defn update-trie-table () :
-    while not empty?(stale-trie-tables) :
-      val i = pop(stale-trie-tables)
-      compute-trie-table(i) when not key?(trie-table, i)
-    ensure-no-stale-tables!()
+  defn update-entry (resolver:EncodingResolver) :
+    while not empty?(stale-entries) :
+      val i = pop(stale-entries)
+      compute-entry(i, resolver) when not key?(entries, i)
+    ensure-no-stale-entries!()
 
-  defn ensure-no-stale-tables! () :
+  defn ensure-no-stale-entries! () :
     #if-not-defined(OPTIMIZE) :
       for i in 0 to length(formats) do :
-        if not key?(trie-table, i) :
-          fatal("Trie table %_ is stale." % [i])
+        if not key?(entries, i) :
+          fatal("Branch Table %_ is stale." % [i])
     false
 
   ;==================================================
-  ;========== Computing the Trie Table ==============
+  ;============= Computing the Entry ================
   ;==================================================
-  defn compute-trie-table (i:Int) :
+  defn compute-entry (i:Int, resolver:EncodingResolver) :
     val f* = resolve-format(formats[i])
-    compute-trie-table-entry(trie-table, ct, i, f*)
+    compute(entries, ct, resolver, backend, i, f*)
 
   defn resolve-format (f:BranchFormat) :
     match(f:MultiFormat) : ResolvedMultiFormat(num-header-args(f), methods-of-multi(multi(f)))
@@ -159,7 +174,7 @@ public defn BranchTable (ct:ClassTable) :
     format-table[bf] = i
     match(bf:MultiFormat) :
       add(multi-formats, multi(bf), i)
-    invalidate-table(i)
+    invalidate-entry(i)
     i
 
   ;==================================================
@@ -169,12 +184,12 @@ public defn BranchTable (ct:ClassTable) :
     add(methods, LoadedMethod(multi(m), types(m), fid(m), package-name, instance?(m)))
     val id = length(methods) - 1
     method-class-dependencies[id] = class-dependencies(m)
-    invalidate-tables-of-multi(multi(m))
+    invalidate-entries-of-multi(multi(m))
     method-multi-table[id] = [multi(m)]
 
   defn remove-method (i:Int) :
     val m = methods[i] as LoadedMethod
-    invalidate-tables-of-multi(multi(m))
+    invalidate-entries-of-multi(multi(m))
     method-class-dependencies[i] = []
     methods[i] = false
     method-multi-table[i] = []
@@ -211,8 +226,8 @@ public defn BranchTable (ct:ClassTable) :
     ;class tree changes.
     new TreeListener :
       defmethod node-changed (this, c:Int) :
-        do(invalidate-table, formats-dependent-on-class(c))
-        do(invalidate-tables-of-multi, multis-dependent-on-class(c))
+        do(invalidate-entry, formats-dependent-on-class(c))
+        do(invalidate-entries-of-multi, multis-dependent-on-class(c))
   add(ct, class-change-listener())
 
   ;==================================================
@@ -225,31 +240,17 @@ public defn BranchTable (ct:ClassTable) :
       match(get?(format-table, f)) :
         (i:Int) : i
         (_:False) : add-format(f)
-    defmethod update (this) :
-      update-trie-table()
-    defmethod trie-table (this) :
-      trie-table
+    defmethod update (this, resolver:EncodingResolver) :
+      update-entry(resolver)
     defmethod load-package-methods (this, package:Symbol, ms:Seqable<VMMethod>) :
       load-package-methods(package, ms)
-
-;==================================================
-;============ Retrieve Trie Table Data ============
-;==================================================
-defmulti trie-table (bt:BranchTable) -> PtrBuffer
-public lostanza defn trie-table-data (bt:ref<BranchTable>) -> ptr<ptr<int>> :
-  return trie-table(bt).data
-
-;==================================================
-;============ Compute a Trie Table Entry ==========
-;==================================================
-lostanza defn compute-trie-table-entry (trie-table:ref<PtrBuffer>,
-                                        class-table:ref<ClassTable>,
-                                        i:ref<Int>,
-                                        f:ref<BranchFormat>) -> ref<False> :
-  val p = to-trie-table(class-table, f)
-  set(trie-table, i.value, p)
-  return false
-
+    defmethod trie-table (this) :
+      trie-table(trie-entries)
+    defmethod dispatchers (this) :
+      dispatchers(func-entries)
+    defmethod runtime (this) :
+      rt
+    
 ;============================================================
 ;==================== Utilities =============================
 ;============================================================
@@ -291,6 +292,158 @@ defn multi-dependencies (f:BranchFormat) :
     (f:MultiFormat) : [multi(f)]
     (f:DispatchFormat|MatchFormat) : []
 
+
+;**************************************************
+;************** TRIE TABLE BACKEND ****************
+;**************************************************
+
+;==================================================
+;============ Retrieve Trie Table Data ============
+;==================================================
+defmulti trie-table (bt:BranchTable) -> PtrBuffer
+public lostanza defn trie-table-data (bt:ref<BranchTable>) -> ptr<ptr<int>> :
+  return trie-table(bt).data
+public lostanza defn dispatchers-data (bt:ref<BranchTable>) -> ptr<long> :
+  return dispatchers(bt).data as ptr<long>
+
+;==================================================
+;============ Compute a Trie Table Entry ==========
+;==================================================
+lostanza defn compute-trie-table-entry (trie-table:ref<PtrBuffer>,
+                                        class-table:ref<ClassTable>,
+                                        i:ref<Int>,
+                                        f:ref<BranchFormat>) -> ref<False> :
+  val p = to-trie-table(class-table, f)
+  set(trie-table, i.value, p)
+  return false
+
+;Conversion of a Vector<int> into a ptr<int>
+lostanza defn to-int-ptr (xs:ref<Vector<Int>>) -> ptr<int> :
+  val n = length(xs).value
+  val p:ptr<int> = call-c clib/malloc(n * sizeof(int))
+  for (var i:int = 0, i < n, i = i + 1) :
+    p[i] = get(xs, new Int{i}).value
+  return p
+
+;Conversion of a BranchFormat into a ptr<int>
+lostanza defn to-trie-table (ct:ref<ClassTable>, f:ref<BranchFormat>) -> ptr<int> :
+  val ints = encode-branch-format(ct, f)
+  return to-int-ptr(ints)
+
+;==================================================
+;================ Compute Dispatcher ==============
+;==================================================
+lostanza defn compute-func-entry (rt:ref<JitRuntime>,
+                                        resolver:ref<EncodingResolver>,
+                                        backend:ref<Backend>,
+                                        dispatchers:ref<FuncBuffer>,
+                                        class-table:ref<ClassTable>,
+                                        i:ref<Int>,
+                                        f:ref<BranchFormat>) -> ref<False> :
+  val d = to-func(rt, resolver, backend, class-table, f, i)
+  set(dispatchers, i.value, d.value)
+  return false
+
+;Conversion of a BranchFormat into dispatcher Code
+lostanza defn to-func (rt:ref<JitRuntime>, resolver:ref<EncodingResolver>, backend:ref<Backend>, ct:ref<ClassTable>, f:ref<BranchFormat>, idx:ref<Int>) -> ref<Func> :
+  val code = jit-branch-format(rt, resolver, backend, ct, f, idx)
+  return code
+
+;<doc>=======================================================
+;================ Encoding of Branch Formats ================
+;============================================================
+
+# Conversion of a Typeset into an Arg #
+
+Input:
+  ct:ClassTable
+  t:TypeSet
+Output:
+  arg:Arg
+
+# Conversion of a BranchFormat into an encoded Vector<Int> #
+
+Input:
+  ct:ClassTable
+  f:BranchFormat
+Output:
+  table:Vector<Int>
+
+# Conversion of a Vector<int> into a ptr<int> #
+
+Input:
+  xs:Vector<Int>
+Output:
+  ys:ptr<int>
+
+# Conversion of a BranchFormat into a ptr<int> #
+
+Input:
+  ct:ref<ClassTable>
+  f:ref<BranchFormat>
+Output:
+  table:ptr<int>
+
+;============================================================
+;=======================================================<doc>
+
+;Encoding a sequence of TypeSets into a dispatch branch
+defn make-branch-table (ct:ClassTable, branches:Seqable<Seqable<TypeSet>>) :
+  within log-time(MAKE-BRANCH-TABLE) :
+    DagBranchTable(
+      to-branches(branches, set-representation{ct, _}),
+      abstract-classes(ct))
+
+;Convert a BranchFormat to a tuple of IBranch
+defn encode-branch-format (ct:ClassTable, f:BranchFormat) -> Vector<Int> :
+  match(f) :
+    (f:MatchFormat) :
+      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
+        val branch-table = make-branch-table(ct, branches(f))
+        compute-dispatch-dag(branch-table, false)
+      defn soln-id (s:Soln) :
+        match(s) :
+          (s:NoSoln) : 0
+          (s:UniqueSoln) : index(s) + 1
+      encode-dag(dag, 0, soln-id)
+    (f:DispatchFormat) :
+      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
+        val branch-table = make-branch-table(ct, branches(f))
+        compute-dispatch-dag(branch-table, true)      
+      defn soln-id (s:Soln) :
+        match(s) :
+          (s:NoSoln) : 0
+          (s:AmbSoln) : 1
+          (s:UniqueSoln) : index(s) + 2
+      encode-dag(dag, 0, soln-id)
+    (f:ResolvedMultiFormat) :
+      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
+        val branch-table = make-branch-table(ct, seq(types,methods(f)))
+        compute-dispatch-dag(branch-table, true)
+      defn soln-id (s:Soln) :
+        match(s) :
+          (s:NoSoln) : 0
+          (s:AmbSoln) : 1
+          (s:UniqueSoln) : fid(methods(f)[index(s)]) + 2
+      encode-dag(dag, num-header-args(f), soln-id)
+
+;============================================================
+;============== TrieBranchEntries Datastructure =============
+;============================================================
+
+defstruct TrieBranchEntries <: BranchEntries :
+  trie-table : PtrBuffer
+
+defmethod remove (entries:TrieBranchEntries, i:Int) :
+  remove(trie-table(entries), i)
+  false
+
+defmethod compute (entries:TrieBranchEntries, ct:ClassTable, resolver:EncodingResolver, backend:Backend, i:Int, f:BranchFormat) :
+  compute-trie-table-entry(trie-table(entries), ct, i, f)
+
+defmethod key? (entries:TrieBranchEntries, i:Int) :
+  key?(trie-table(entries), i)
+  
 ;<doc>=======================================================
 ;================== PtrBuffer Datastructure =================
 ;============================================================
@@ -390,93 +543,158 @@ lostanza defn remove (b:ref<PtrBuffer>, i:ref<Int>) -> ref<True|False> :
   else :
     return false
 
-;<doc>=======================================================
-;================ Encoding of Branch Formats ================
+;**************************************************
+;************ DISPATCH TABLE BACKEND **************
+;**************************************************
+
+;============================================================
+;============ DispatchBranchEntries Datastructure ===========
 ;============================================================
 
-# Conversion of a Typeset into an Arg #
+defstruct FuncBranchEntries <: BranchEntries :
+  dispatchers : FuncBuffer
+  rt : JitRuntime
+
+defmethod remove (entries:FuncBranchEntries, i:Int) :
+  remove(dispatchers(entries), i)
+  false
+
+defmethod compute (entries:FuncBranchEntries, ct:ClassTable, resolver:EncodingResolver, backend:Backend, i:Int, f:BranchFormat) :
+  compute-func-entry(rt(entries), resolver, backend, dispatchers(entries), ct, i, f)
+
+defmethod key? (entries:FuncBranchEntries, i:Int) :
+  key?(dispatchers(entries), i)
+  
+;<doc>=======================================================
+;================= FuncBuffer Datastructure =================
+;============================================================
+
+# Creation of FuncBuffer #
 
 Input:
-  ct:ClassTable
-  t:TypeSet
+  n:ref<Int>
 Output:
-  arg:Arg
+  buffer:ref<FuncBuffer>
 
-# Conversion of a BranchFormat into an encoded Vector<Int> #
+# Store new pointer into FuncBuffer #
 
 Input:
-  ct:ClassTable
-  f:BranchFormat
-Output:
-  table:Vector<Int>
+  b:ref<FuncBuffer>
+  i:int
+  p:ptr<?>
 
-# Conversion of a Vector<int> into a ptr<int> #
+# Retrieve the data pointer of ref<FuncBuffer> #
 
-Input:
-  xs:Vector<Int>
-Output:
-  ys:ptr<int>
+  p.data
 
-# Conversion of a BranchFormat into a ptr<int> #
+# Check whether key i exists in FuncBuffer #
 
 Input:
-  ct:ref<ClassTable>
-  f:ref<BranchFormat>
+  b:ref<FuncBuffer>
+  i:ref<Int>
 Output:
-  table:ptr<int>
+  exists?:ref<True|False>
+
+# Remove an entry i from FuncBuffer #
+
+Input:
+  b:ref<FuncBuffer>
+  i:ref<Int>
+Output:
+  removed?:ref<True|False>
 
 ;============================================================
 ;=======================================================<doc>
 
-;Encoding a sequence of TypeSets into a dispatch branch
-defn make-branch-table (ct:ClassTable, branches:Seqable<Seqable<TypeSet>>) :
-  within log-time(MAKE-BRANCH-TABLE) :
-    DagBranchTable(
-      to-branches(branches, set-representation{ct, _}),
-      abstract-classes(ct))
+public lostanza deftype FuncBuffer :
+  rt : ref<JitRuntime>
+  var length: int
+  var data: ptr<ptr<?>>
 
-;Convert a BranchFormat to a tuple of IBranch
-defn encode-branch-format (ct:ClassTable, f:BranchFormat) -> Vector<Int> :
+lostanza defn FuncBuffer (rt:ref<JitRuntime>, n:ref<Int>) -> ref<FuncBuffer> :
+  val len = n.value
+  val data:ptr<ptr<?>> = call-c clib/malloc(len * sizeof(ptr<?>))
+  for (var i:int = 0, i < len, i = i + 1) :
+    data[i] = null
+  return new FuncBuffer{rt, len, data}
+
+lostanza defn ensure-capacity (p:ref<FuncBuffer>, c:int) -> int :
+  val l0 = p.length
+  if l0 < c :
+    ;Compute new length
+    var l:int = l0
+    while l < c : l = l * 2
+    ;Allocate new data, and copy old stuff over
+    val data:ptr<ptr<?>> = call-c clib/malloc(l * sizeof(ptr<?>))
+    call-c clib/memcpy(data, p.data, l0 * sizeof(ptr<?>))
+    ;Void out left over slots
+    for (var i:int = l0, i < l, i = i + 1) :
+      data[i] = null
+    ;Free old data, and set new data and length
+    call-c clib/free(p.data)
+    p.data = data
+    p.length = l
+  return 0
+
+lostanza defn set (p:ref<FuncBuffer>, i:int, p*:ptr<?>) -> int :
+  ensure-capacity(p, i + 1)
+  ;Free old ptr
+  val p0 = p.data[i]
+  if p0 != null : release(p.rt, new Long{p0 as long})
+  ;Store new ptr
+  p.data[i] = p*    
+  return 0
+
+lostanza defn key? (b:ref<FuncBuffer>, i:ref<Int>) -> ref<True|False> :
+  if i.value < b.length :
+    val p = b.data[i.value]
+    if p == null : return false
+    else : return true
+  else :
+    return false
+
+lostanza defn remove (b:ref<FuncBuffer>, i:ref<Int>) -> ref<True|False> :
+  if i.value < b.length :
+    val p = b.data[i.value]
+    if p == null :
+      return false
+    else :
+      release(b.rt, new Long{p as long})
+      b.data[i.value] = null
+      return true
+  else :
+    return false
+
+;============================================================
+;============================================================
+
+;Convert a BranchFormat to dispatcher Code
+defn jit-branch-format (rt:JitRuntime, resolver:EncodingResolver, backend:Backend, ct:ClassTable, f:BranchFormat, idx:Int) -> Func :
   match(f) :
-    (f:MatchFormat) :
-      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
-        val branch-table = make-branch-table(ct, branches(f))
-        compute-dispatch-dag(branch-table, false)
+    (f:MatchFormat) :    
+      val branch-table = make-branch-table(ct, branches(f))
+      val dag = compute-dispatch-dag(branch-table, false)
       defn soln-id (s:Soln) :
         match(s) :
           (s:NoSoln) : 0
           (s:UniqueSoln) : index(s) + 1
-      encode-dag(dag, 0, soln-id)
+      jit-dag(rt, resolver, backend, dag, 0, soln-id, idx)
     (f:DispatchFormat) :
-      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
-        val branch-table = make-branch-table(ct, branches(f))
-        compute-dispatch-dag(branch-table, true)      
+      val branch-table = make-branch-table(ct, branches(f))
+      val dag = compute-dispatch-dag(branch-table, true)
       defn soln-id (s:Soln) :
         match(s) :
           (s:NoSoln) : 0
           (s:AmbSoln) : 1
           (s:UniqueSoln) : index(s) + 2
-      encode-dag(dag, 0, soln-id)
+      jit-dag(rt, resolver, backend, dag, 0, soln-id, idx)
     (f:ResolvedMultiFormat) :
-      val dag = within log-time(BRANCH-TABLE-DISPATCH-DAG) :
-        val branch-table = make-branch-table(ct, seq(types,methods(f)))
-        compute-dispatch-dag(branch-table, true)
+      val branch-table = make-branch-table(ct, seq(types,methods(f)))
+      val dag = compute-dispatch-dag(branch-table, true)
       defn soln-id (s:Soln) :
         match(s) :
           (s:NoSoln) : 0
           (s:AmbSoln) : 1
           (s:UniqueSoln) : fid(methods(f)[index(s)]) + 2
-      encode-dag(dag, num-header-args(f), soln-id)
+      jit-dag(rt, resolver, backend, dag, num-header-args(f), soln-id, idx)
 
-;Conversion of a Vector<int> into a ptr<int>
-lostanza defn to-int-ptr (xs:ref<Vector<Int>>) -> ptr<int> :
-  val n = length(xs).value
-  val p:ptr<int> = call-c clib/malloc(n * sizeof(int))
-  for (var i:int = 0, i < n, i = i + 1) :
-    p[i] = get(xs, new Int{i}).value
-  return p
-
-;Conversion of a BranchFormat into a ptr<int>
-lostanza defn to-trie-table (ct:ref<ClassTable>, f:ref<BranchFormat>) -> ptr<int> :
-  val ints = encode-branch-format(ct, f)
-  return to-int-ptr(ints)

--- a/compiler/branch-table.stanza
+++ b/compiler/branch-table.stanza
@@ -330,25 +330,6 @@ lostanza defn to-trie-table (ct:ref<ClassTable>, f:ref<BranchFormat>) -> ptr<int
   val ints = encode-branch-format(ct, f)
   return to-int-ptr(ints)
 
-;==================================================
-;================ Compute Dispatcher ==============
-;==================================================
-lostanza defn compute-func-entry (rt:ref<JitRuntime>,
-                                        resolver:ref<EncodingResolver>,
-                                        backend:ref<Backend>,
-                                        dispatchers:ref<FuncBuffer>,
-                                        class-table:ref<ClassTable>,
-                                        i:ref<Int>,
-                                        f:ref<BranchFormat>) -> ref<False> :
-  val d = to-func(rt, resolver, backend, class-table, f, i)
-  set(dispatchers, i.value, d.value)
-  return false
-
-;Conversion of a BranchFormat into dispatcher Code
-lostanza defn to-func (rt:ref<JitRuntime>, resolver:ref<EncodingResolver>, backend:ref<Backend>, ct:ref<ClassTable>, f:ref<BranchFormat>, idx:ref<Int>) -> ref<Func> :
-  val code = jit-branch-format(rt, resolver, backend, ct, f, idx)
-  return code
-
 ;<doc>=======================================================
 ;================ Encoding of Branch Formats ================
 ;============================================================
@@ -565,6 +546,25 @@ defmethod compute (entries:FuncBranchEntries, ct:ClassTable, resolver:EncodingRe
 defmethod key? (entries:FuncBranchEntries, i:Int) :
   key?(dispatchers(entries), i)
   
+;==================================================
+;================ Compute Dispatcher ==============
+;==================================================
+lostanza defn compute-func-entry (rt:ref<JitRuntime>,
+                                  resolver:ref<EncodingResolver>,
+                                  backend:ref<Backend>,
+                                  dispatchers:ref<FuncBuffer>,
+                                  class-table:ref<ClassTable>,
+                                  i:ref<Int>,
+                                  f:ref<BranchFormat>) -> ref<False> :
+  val d = to-func(rt, resolver, backend, class-table, f, i)
+  set(dispatchers, i.value, d.value)
+  return false
+
+;Conversion of a BranchFormat into dispatcher Code
+lostanza defn to-func (rt:ref<JitRuntime>, resolver:ref<EncodingResolver>, backend:ref<Backend>, ct:ref<ClassTable>, f:ref<BranchFormat>, idx:ref<Int>) -> ref<Func> :
+  val code = jit-branch-format(rt, resolver, backend, ct, f, idx)
+  return code
+
 ;<doc>=======================================================
 ;================= FuncBuffer Datastructure =================
 ;============================================================

--- a/compiler/cvm-code-table.stanza
+++ b/compiler/cvm-code-table.stanza
@@ -32,17 +32,17 @@ lostanza defmethod instructions (t:ref<CVMCodeTable>) -> ref<Long> :
 
 lostanza defmethod load-function (table:ref<CVMCodeTable>,
                                   fid:ref<Int>,
-                                  func:ref<VMFunction>,
+                                  vm-func:ref<VMFunction>,
                                   externfn?:ref<True|False>,
                                   resolver:ref<EncodingResolver>,
                                   backend:ref<Backend>) -> ref<LoadedFunction> :
   ;Encode the function using the CVM encoder.
-  val encoded-function = encode(func, resolver, backend)
+  val encoded-function = encode(vm-func, resolver, backend)
 
   ;Load the bytecode into the bytecode vector.
-  val num-bytes = length(buffer(encoded-function))
+  val num-bytes = length(byte-buffer!(encoded-function))
   val offset = alloc(table.bytecode, num-bytes.value)
-  call-c clib/memcpy(table.bytecode.mem + offset, data(buffer(encoded-function)), num-bytes.value)
+  call-c clib/memcpy(table.bytecode.mem + offset, data(byte-buffer!(encoded-function)), num-bytes.value)
 
   ;Add the offset to the trace entries so that we know their absolute position.
   val relocated-trace-entries = add-offset(trace-entries(encoded-function), new Long{offset})

--- a/compiler/cvm-encoder.stanza
+++ b/compiler/cvm-encoder.stanza
@@ -14,10 +14,16 @@ defpackage stz/cvm-encoder :
   import stz/code-table
   import stz/vm-opcodes
   import stz/trace-info
+  import stz/asmjit
+  import stz/params
 
 public defstruct EncodedFunction :
-  buffer: ByteBuffer
+  jit?: True|False
+  func: ByteBuffer|Func
   trace-entries: Vector<TraceTableEntry>
+
+public defn byte-buffer! (f:EncodedFunction) -> ByteBuffer :
+  func(f) as ByteBuffer
 
 public defn encode (func:VMFunction,
                     resolver:EncodingResolver,
@@ -698,7 +704,7 @@ public defn encode (func:VMFunction,
   ;Use delayed actions and encode instructions
   within delay-actions() :
     encode(func as VMMultifn|VMFunc)
-  EncodedFunction(buffer, trace-entry-table)
+  EncodedFunction(contains?(EXPERIMENTAL-FEATURES, `jit), buffer, trace-entry-table)
 
 ;============================================================
 ;====================== Utilities ===========================

--- a/compiler/jit-code-table.stanza
+++ b/compiler/jit-code-table.stanza
@@ -8,6 +8,7 @@ defpackage stz/jit-code-table :
   import stz/asmjit
   import stz/jit-encoder
   import stz/vm-structures
+  import stz/branch-table
 
 ;============================================================
 ;================= Struct Definition ========================
@@ -29,8 +30,8 @@ public defstruct JITStubs :
 ;================== Constructor =============================
 ;============================================================
 
-public defn JITCodeTable (resolver:EncodingResolver, backend:Backend) -> JITCodeTable :
-  val runtime = jit-runtime-new()
+public defn JITCodeTable (resolver:EncodingResolver, backend:Backend, branch-table:BranchTable) -> JITCodeTable :
+  val runtime = runtime(branch-table) as JitRuntime
   val stubs = make-jit-stubs(runtime, resolver, backend)  
   #JITCodeTable(runtime, stubs)
 

--- a/compiler/jit-encoder.stanza
+++ b/compiler/jit-encoder.stanza
@@ -19,6 +19,11 @@ defpackage stz/jit-encoder :
   import stz/shuffle
   import stz/timing-log-api
   import stz/trace-info
+  import stz/binary-tree
+  import stz/asm-ir-utils
+  import stz/asm-ir with:
+    prefix(Label, Loc, Reg, SetIns, EqOp) => asm-ir-
+  
 
 ;============================================================
 ;===================== JIT Encoder ==========================
@@ -346,6 +351,7 @@ defmulti emit-function-prelude (gen:AsmGen, args:Tuple<Local|VMType>, extend-sta
 defmulti emit-arg-bit-extensions (gen:AsmGen, args:Tuple<Local|VMType>) -> False
 defmulti emit-multi-arity-dispatch (emit-arity-code:Int|False -> False, gen:AsmGen, arity-arg:Int, arities:Tuple<Int>) -> False
 defmulti emit-ins (gen:AsmGen, ins:VMIns) -> False
+defmulti emit-dispatch-dag (gen:AsmGen, rt:JitRuntime, backend:Backend, dag:Dag, start-depth:Int, soln-id:Soln -> Int, idx:Int) -> False
 defenum EnterExit: (Enter, Exit)
 
 ;The information about a function's local frame.
@@ -378,6 +384,7 @@ defn AsmGen (code:CodeHolder,
   defn callc-freg (i:Int) : callc-fregs(registers)[i]
   defn callc-ret () : callc-return(registers)
   defn callc-fret () : callc-freturn(registers)
+
 
   ;=========================================================
   ;============== Function Stack Frame =====================
@@ -494,6 +501,7 @@ defn AsmGen (code:CodeHolder,
                       get-vmstate-current-stack
                       get-vmstate-system-stack
                       get-vmstate-system-registers
+                      get-vmstate-dispatchers
                       get-return
                       get-liveness-map
                       get-stack-size
@@ -515,6 +523,7 @@ defn AsmGen (code:CodeHolder,
                       set-vmstate-current-stack
                       set-vmstate-system-stack
                       set-vmstate-system-registers
+                      set-vmstate-dispatchers
                       set-return
                       set-liveness-map
                       set-stack-size
@@ -522,6 +531,7 @@ defn AsmGen (code:CodeHolder,
                       set-stack-pointer
                       set-stack-pc]
         BaseReg in [VMStateReg
+                    VMStateReg
                     VMStateReg
                     VMStateReg
                     VMStateReg
@@ -557,6 +567,7 @@ defn AsmGen (code:CodeHolder,
                    VMSTATE-CURRENT-STACK-OFFSET
                    VMSTATE-SYSTEM-STACK-OFFSET
                    VMSTATE-SYSTEM-REGISTERS-OFFSET
+                   VMSTATE-DISPATCHERS-OFFSET
                    STACK-FRAME-RETURN-OFFSET
                    STACK-FRAME-LIVENESS-MAP-OFFSET
                    STACK-SIZE-OFFSET
@@ -578,6 +589,7 @@ defn AsmGen (code:CodeHolder,
                    vmstate-current-stack-memptr
                    vmstate-system-stack-memptr
                    vmstate-system-registers-memptr
+                   vmstate-dispatchers-memptr
                    stack-frame-return-memptr
                    stack-frame-liveness-map-memptr
                    stack-size-memptr
@@ -1326,20 +1338,21 @@ defn AsmGen (code:CodeHolder,
   ;=========================================================
   ;=================== Dispatch ============================
   ;=========================================================
-  ;Emit instructions for reading the dispatch table with the current
+  ;Emit instructions for reading and calling the dispatcher table with the current
   ;values in the vmstate.registers array.
-  ;Uses Tmp1 internally.
   defn read-dispatch-table (dst:Gp, format:Int) -> False :
-    mov(a, reg(Tmp1), format)
-    val args = [reg(VMStateReg), reg(Tmp1)]
-    simple-call-c-from-jit-context(dst, read-dispatch-table-addr(), args)
+    val dispatchers = get-vmstate-dispatchers(rax)
+    val dispatcher = mov(a, rax, MemPtr(dispatchers, format * SIZEOF-LONG, SIZEOF-LONG))
+    call(a, dispatcher)
+    mov(a, dst, rax)
+    false
 
   ;Emit instructions for performing a dispatch according to the given format
   ;to the set of given labels.
   defn emit-dispatch (format:Int, ys:Tuple<VMImm>, labels:Tuple<Label>) -> False :
     ;Put dispatch arguments into registers.
     set-regs(ys)
-    
+        
     ;Emit idx (Tmp1) = read-dispatch-table(format)
     read-dispatch-table(reg(Tmp1), format)
 
@@ -2940,6 +2953,148 @@ defn AsmGen (code:CodeHolder,
     ;Default branch
     emit-arity-code(false)
 
+  defn jit-dag (rt:JitRuntime, backend:Backend, dag:Dag, start-depth:Int, soln-id:Soln -> Int, idx:Int) :
+    ;Return the numerical tag for the given global id
+    defn tag-imm (cid:Int, marker?:True|False) :
+      if marker? : INT(cid << 3 + 2)
+      else : INT(cid)
+
+    ;Calculate labels for all entries
+    val labels = map(new-label{a}, entries(dag))
+    val leaf-labels = IntTable<Label>()
+    defn to-label (v:Int|Soln) -> Label :
+      match(v) :
+        (v:Int) : labels[v]
+        (v:Soln) :
+          val id = soln-id(v)
+          match(get?(leaf-labels, id, false)) :
+            (lab:Label) :
+              lab
+            (lab:False) :
+              val new-lab = new-label(a)
+              leaf-labels[id] = new-lab
+              new-lab
+
+    ;Emit a single dag entry
+    defn emit-dag-entry (dag-e:DagEntry) :
+      if empty?(entries(dag-e)) :
+        jmp(a, to-label(default(dag-e)))
+      else :
+        ;Categorize branches
+        val prim-targets = Vector<KeyValue<Int,Label>>()
+        val marker-targets = Vector<KeyValue<Int,Label>>()
+        val ref-targets = Vector<KeyValue<Int,Label>>()
+        val default-target = to-label(default(dag-e))
+        for entry in entries(dag-e) do :
+          val tgt = to-label(value(entry))
+          for x in values(key(entry))  do :
+            if x == BYTE-TYPE : add(prim-targets, x => tgt)
+            else if x == CHAR-TYPE : add(prim-targets, x => tgt)
+            else if x == INT-TYPE : add(prim-targets, x => tgt)
+            else if x == FLOAT-TYPE : add(prim-targets, x => tgt)
+            else if marker?(resolver, x) : add(marker-targets, x => tgt)
+            else : add(ref-targets, x => tgt)              
+
+        ;Registers
+        val OBJ = Tmp1
+        val BITS = Tmp2
+        val TAG = Tmp2
+
+        ;Load object
+        val object = mov(a, reg(Tmp3), vm-register(start-depth + depth(dag-e)))
+
+        ;Test bits
+        val marker-branches = new-label(a)
+        val ref-branches = new-label(a)
+        val prim-targets? = not empty?(prim-targets)
+        val marker-targets? = not empty?(marker-targets)
+        val ref-targets? = not empty?(ref-targets)
+
+        ;Checking for primitives or references requires knowing the tag bits.
+        ;So create the tag bits if we have either case.
+        if prim-targets? or ref-targets? :
+          mov(a, reg(BITS), object)
+          and-op(a, reg(BITS), 7)
+
+        ;Jump to the appropriate primitive target if the object
+        ;is one of the given primitives.
+        for entry in prim-targets do :
+          val x = key(entry)
+          val target = value(entry)
+          val tagbits = tagbits(resolver, x)
+          cmp(a, reg(BITS), tagbits)
+          je(a, target)
+
+        ;Skip the reference branches if the object is not a reference.
+        val label-after-refs = marker-branches when marker-targets?
+                          else default-target
+        if ref-targets? :
+          cmp(a, reg(BITS), 1)
+          jne(a, label-after-refs)
+        else if not marker-targets? :
+          jmp(a, label-after-refs)
+
+        ;Jump to the appropriate reference branches if the object
+        ;is one of the given references
+        if ref-targets? :
+          defn ref-tree () :
+            BinaryNode $ for e in ref-targets seq :
+              val header = tag-imm(key(e), false)
+              (value(header) as Int) => value(e)
+          bind(a, ref-branches)
+          mov(a, reg(TAG), MemPtr(object, -1, SIZEOF-LONG))
+          let loop (tree:BinaryNode<Label> = ref-tree()) :
+            match(tree) :
+              (tree:InnerNode<Label>) :
+                val left-tree = new-label(a)
+                cmp(a, reg(TAG), value(tree))
+                jbe(a, left-tree)
+                loop(right(tree))
+                bind(a, left-tree)
+                loop(left(tree))
+              (tree:LeafNode<Label>) :
+                for e in entries(tree) do :
+                  val x = key(e)
+                  val target = value(e)
+                  cmp(a, reg(TAG), x)
+                  je(a, target)
+                jmp(a, default-target)
+
+        ;Jump to the appropriate marker branches if the object is one
+        ;of the given marker branches.
+        if marker-targets? :
+          defn marker-tree () :
+            BinaryNode $ for e in marker-targets seq :
+              val header = tag-imm(key(e), true)
+              (value(header) as Int) => value(e)
+          bind(a, marker-branches)
+          let loop (tree:BinaryNode<Label> = marker-tree()) :
+            match(tree) :
+              (tree:InnerNode<Label>) :
+                val left-tree = new-label(a)
+                cmp(a, object, value(tree))
+                jbe(a, left-tree)
+                loop(right(tree))
+                bind(a, left-tree)
+                loop(left(tree))
+              (tree:LeafNode<Label>) :
+                for e in entries(tree) do :
+                  val x = key(e)
+                  val target = value(e)
+                  cmp(a, object, x)
+                  je(a, target)
+                jmp(a, default-target)
+
+    ;Emit all entries
+    for (e in entries(dag), l in labels) do :
+      bind(a, l)
+      emit-dag-entry(e)
+
+    for entry in leaf-labels do :
+      bind(a, value(entry))
+      mov(a, rax, key(entry))
+      ret(a)
+
   ;=========================================================
   ;============= Return Asm Generation Utilities ===========
   ;=========================================================
@@ -2956,6 +3111,8 @@ defn AsmGen (code:CodeHolder,
       emit-multi-arity-dispatch(emit-arity-code, arity-arg, arities)
     defmethod emit-ins (this, ins:VMIns) :
       emit-ins(ins)
+    defmethod emit-dispatch-dag (this, rt:JitRuntime, backend:Backend, dag:Dag, start-depth:Int, soln-id:Soln -> Int, idx:Int) :
+      jit-dag(rt, backend, dag, start-depth, soln-id, idx)
 
 ;============================================================
 ;================= Compile Stubs ============================
@@ -2970,6 +3127,11 @@ public defn make-jit-stubs (rt:JitRuntime, resolver:EncodingResolver, backend:Ba
   JITStubs(
     make-stub-func(emit-jit-launch)
     make-stub-func(emit-extend-stack))
+
+public defn jit-dag (rt:JitRuntime, resolver:EncodingResolver, backend:Backend, dag:Dag, start-depth:Int, soln-id:Soln -> Int, idx:Int) -> Func :
+  within (code, assembler) = gen-code(rt) :
+    val gen = AsmGen(code, assembler, resolver, false, false, backend)
+    emit-dispatch-dag(gen, rt, backend, dag, start-depth, soln-id, idx)
 
 ;============================================================
 ;======== Compute Absolute Addresses of Trace Entries =======
@@ -3048,3 +3210,9 @@ public defn encode (func:VMFunction,
 
     ;Return the final encoded function
     EncodedFunction(jit-func, trace-entry-table)
+
+;============================================================
+;====================== JIT DAG =============================
+;============================================================
+
+

--- a/compiler/vm-structures.stanza
+++ b/compiler/vm-structures.stanza
@@ -35,6 +35,7 @@ public lostanza deftype VMState :
   ;Interpreted Mode Tables
   var instructions: ptr<byte>      ;(Permanent State)
   var trie-table: ptr<ptr<int>>    ;(Permanent State)
+  var dispatchers: ptr<long>       ;(Permanent State)
 
 ;- code: The integer id of the function. The VM
 ;  will retrieve the address of the code by looking up
@@ -80,6 +81,8 @@ public lostanza val VMSTATE-REGISTERS-OFFSET:ref<Int> =
   new Int{addr(null-vmstate().registers) as long as int}
 public lostanza val VMSTATE-SYSTEM-REGISTERS-OFFSET:ref<Int> =
   new Int{addr(null-vmstate().system-registers) as long as int}
+public lostanza val VMSTATE-DISPATCHERS-OFFSET:ref<Int> =
+  new Int{addr(null-vmstate().dispatchers) as long as int}
 public lostanza val VMSTATE-HEAP-START-OFFSET:ref<Int> =
   new Int{addr(null-vmstate().heap.start) as long as int}
 public lostanza val VMSTATE-HEAP-TOP-OFFSET:ref<Int> =

--- a/compiler/vm.stanza
+++ b/compiler/vm.stanza
@@ -26,6 +26,8 @@ defpackage stz/vm :
   import stz/absolute-info
   import stz/trace-info
   import core/stack-trace
+  import stz/asmjit
+  import clib
 
 ;<doc>=======================================================
 ;================= Virtual Machine Interface ================
@@ -341,6 +343,7 @@ lostanza defn update-vmstate (vm:ref<VirtualMachine>) -> ref<False> :
   vms.data-mem = vmt.data.mem
   vms.code-offsets = vmt.function-addresses.data
   vms.trie-table = trie-table-data(branch-table(vm))
+  vms.dispatchers = dispatchers-data(branch-table(vm))
   vms.class-table = packed-class-table(vmt.class-table)
   return false
 
@@ -356,6 +359,8 @@ public defn VirtualMachine (dylibs:LoadedDynamicLibraries) :
       VirtualMachine(dylibs, L64Backend())
     #else :
       VirtualMachine(dylibs, X64Backend())
+
+defn jit? () : contains?(EXPERIMENTAL-FEATURES, `jit)
 
 public lostanza defn VirtualMachine (dylibs:ref<LoadedDynamicLibraries>, backend:ref<Backend>) -> ref<VirtualMachine> :
   val vmstate:ptr<VMState> = call-c clib/malloc(sizeof(VMState))
@@ -379,10 +384,10 @@ public lostanza defn VirtualMachine (dylibs:ref<LoadedDynamicLibraries>, backend
   val extern-defns = ExternDefnTable(backend)
   val vm-ids = VMIds(dylibs, extern-defns)
   val class-table = ClassTable()
-  val branch-table = BranchTable(class-table)
+  val branch-table = BranchTable(class-table, jit?(), backend)
   val linker = Linker(branch-table)
   val resolver = EncodingResolver(class-table, branch-table, live-map-table(linker), dylibs, extern-defns)
-  val code-table = make-code-table(resolver, backend)
+  val code-table = make-code-table(resolver, backend, branch-table)
   val vmtable = VMTable(class-table, branch-table, code-table)
   val vm = new VirtualMachine{dylibs, extern-defns, backend, vmtable, vm-ids, linker, vmstate, false}
   update-vmstate(vm)
@@ -390,8 +395,8 @@ public lostanza defn VirtualMachine (dylibs:ref<LoadedDynamicLibraries>, backend
 
 ;Make an appropriate CodeTable depending on whether the user has
 ;enabled the JIT.
-defn make-code-table (resolver:EncodingResolver, backend:Backend) -> CodeTable :
-  if contains?(EXPERIMENTAL-FEATURES, `jit) : JITCodeTable(resolver, backend)
+defn make-code-table (resolver:EncodingResolver, backend:Backend, branch-table:BranchTable) -> CodeTable :
+  if jit?() : JITCodeTable(resolver, backend, branch-table)
   else : CVMCodeTable()
 
 lostanza defn vm-iterate-roots (f:ptr<((ptr<long>, ptr<core/VMState>) -> ref<False>)>,
@@ -896,12 +901,12 @@ public defn load (vm:VirtualMachine, vmps:Collection<VMPackage>, keep-existing-g
 
       ;Load functions
       vprintln("VM: Encoding functions")
+      ;Compute the functions that are exposed externally via callbacks.
+      val callback-set = to-intset(seq(function-id, callbacks(load-unit)))
+      ;Create the encoding resolver for compiling the function.
+      val encoding-resolver = EncodingResolver(class-table(vm), branch-table(vm), live-map-table(linker(vm)),
+                                               dynamic-libraries(vm), extern-defns(vm))
       within log-time(LOAD-FUNCTIONS) :
-        ;Compute the functions that are exposed externally via callbacks.
-        val callback-set = to-intset(seq(function-id, callbacks(load-unit)))
-        ;Create the encoding resolver for compiling the function.
-        val encoding-resolver = EncodingResolver(class-table(vm), branch-table(vm), live-map-table(linker(vm)),
-                                                 dynamic-libraries(vm), extern-defns(vm))
         ;Load each of the functions.
         for f in funcs(load-unit) do :
           load-function(vmt, f, callback-set[id(f)], encoding-resolver, backend(vm))
@@ -916,7 +921,7 @@ public defn load (vm:VirtualMachine, vmps:Collection<VMPackage>, keep-existing-g
       ;Update the virtual machine state
       vprintln("VM: Updating branch table")
       within log-time(UPDATE-BRANCH-TABLE) :
-        update(branch-table(vm))
+        update(branch-table(vm), encoding-resolver)
       vprintln("VM: Updating VMState")
       within log-time(UPDATE-VMSTATE) :
         update-vmstate(vm)


### PR DESCRIPTION
Currently, the VM/JIT uses trie-tables that generate data used by C code to look up indices for computing branch taken during multimethod dispatch.  This PR introduces assembly code created JIT to compute the same thing without needing tables.  The dependency tracking and management code stays effectively the same but instead manages vectors of code instead of trie tables.  I introduced a BranchEntries API where I can then backend with Trie Tables or Dispatch funcs.  The Trie Table is still used when JIT experimental feature is not specified.