### PR TITLE
Add check to ensure that duplicate definitions are detected.

### DIFF
--- a/compiler/params.stanza
+++ b/compiler/params.stanza
@@ -18,7 +18,7 @@ public defn compiler-flags () :
   to-tuple(COMPILE-FLAGS)
 
 ;========= Stanza Configuration ========
-public val STANZA-VERSION = [0 18 54] 
+public val STANZA-VERSION = [0 18 55] 
 public var STANZA-INSTALL-DIR:String = ""
 public var OUTPUT-PLATFORM:Symbol = `platform
 public var STANZA-PKG-DIRS:List<String> = List()

--- a/compiler/type-error-formatter.stanza
+++ b/compiler/type-error-formatter.stanza
@@ -2,6 +2,7 @@ defpackage stz/type-error-formatter :
   import core
   import collections
   import stz/tl-ir
+  import stz/dl-ir
   import stz/type-errors
   import stz/namemap
   import stz/type-formatter
@@ -501,7 +502,7 @@ public defn TypeErrorFormatter (namemap:NameMap, hier:TypeHierarchy) :
         (e:BadCapture) :
           val ctxt = ctxt(exp(e))
           "%_Could not capture type variables for function '%_'%_." % [
-          info-str(exp(e)), def-name(n(e)), ctxt-description(ctxt as Context)]
+          info-str(exp(e)), def-name(n(e)), ctxt-description(ctxt as Context)]          
 
 ;Helper: Add single-quotes around x.
 defn quotes (x) :

--- a/compiler/type-errors.stanza
+++ b/compiler/type-errors.stanza
@@ -3,6 +3,7 @@ defpackage stz/type-errors :
   import core
   import collections
   import stz/tl-ir
+  import stz/dl-ir
   import stz/types
   import stz/absolute-info
 
@@ -91,6 +92,22 @@ with:
 
 ;Represents the name of a Stanza package.
 public defstruct PackageName : (name:Symbol)
+
+;Format a duplicate exports deifnition.
+public defmessage DuplicateExports <: TypeError :
+  export1:Export
+  export2:Export
+with:
+  format: 
+    val name-str = match(id(rec(export2))) :
+      (id:ValId) : "variable '%_'" % [name(id)]
+      (id:TypeId) : "type '%_'" % [name(id)]
+      (id:FnId) : "function '%_'" % [name(id)]
+    val prev-str = match(info(export1)) :
+      (info:AbsoluteFileInfo) : " Previous definition at %_." % [info]
+      (f:False) : ""
+    "%_Duplicate definition of %_.%_" % [
+    info-str(info(export2)), name-str, prev-str]
 
 ;============================================================
 ;================== Type Checking Errors ====================

--- a/compiler/type.stanza
+++ b/compiler/type.stanza
@@ -70,7 +70,14 @@ public defn type-program (ipackages:Tuple<IPackage>,
     guard!(tprog-solved, SolvedTL)
 
     ;Return solved tprog with the PackageIO filled.
-    compute-packageios(tprog-solved)
+    val final-tprog = compute-packageios(tprog-solved)
+
+    ;Detect any duplicate errors before finishing.
+    match(duplicate-definitions(final-tprog)) :
+      (e:TypeErrors) : return(e)
+      (f:False) : false
+
+    final-tprog
 
 ;============================================================
 ;============= Gather Exports from Environment ==============
@@ -105,6 +112,25 @@ defn gather-exports (ipackages:Tuple<IPackage>, env:Env) -> Tuple<Export> :
 
   ;Return the accumulated exports.
   to-tuple(export-accum)
+
+;============================================================
+;============== Detect Duplicate Definitions ================
+;============================================================
+
+;Scan through the program now that PackageIO have been computed
+;and issue errors for any duplicate definitions.
+defn duplicate-definitions (prog:TProg) -> TypeErrors|False :
+  val defined = HashTable<RecId,Export>()
+  val errors = Vector<TypeError>()
+  for p in packages(prog) do :
+    for e in exports(packageio(p)) do :
+      if key?(defined, id(rec(e))):
+        val olde = defined[id(rec(e))]
+        add(errors, DuplicateExports(olde, e))
+      else :
+        defined[id(rec(e))] = e
+  if not empty?(errors) :
+    TypeErrors(to-tuple(errors))
 
 ;============================================================
 ;=============== Format Type Errors =========================


### PR DESCRIPTION
This adds a check to the end of TL-IR, so that duplicate definitions are detected and that invalid assembly is not generated.