### PR TITLE
Added `deftype` annotation for definitions database.

### DIFF
--- a/compiler/defs-db-ir.stanza
+++ b/compiler/defs-db-ir.stanza
@@ -55,6 +55,31 @@ doc: "Annotations for `var` and `val` definitions"
 public defstruct DefVarAnnotation <: DefinitionAnnotation :
   mutable?: True|False
 
+doc: "Annotation for `deftype` definitions"
+public defstruct DefTypeAnnotation <: DefinitionAnnotation :
+  doc: \<DOC>
+  Type Arguments for a deftype
+
+  Example:
+    deftype Spoon<T,S>
+
+  Results in:
+    targs = [T, S]
+  <DOC>
+  targs:Tuple<Symbol>
+  doc: \<DOC>
+  Parent types this type is derived from.
+  Contains the symbols for each of the parent types that
+  this type is derived from.
+
+  Example:
+    deftype Warble <: Equalable & Hashable
+
+  Results in:
+    parents = [Equalable, Hashable]
+  <DOC>
+  parents:Tuple<Symbol>
+
 doc: "Annotations given to defn objects."
 public defstruct DefnAnnotation <: DefinitionAnnotation :
   targs:Tuple<Symbol>,
@@ -163,6 +188,15 @@ defmethod print (o:OutputStream, f:DefnAnnotation) :
   val return-type? = return-type?(f)
   match(return-type?:Symbol) : 
     print(o, " -> %_" % [return-type?])
+
+defmethod print (o:OutputStream, f:DefTypeAnnotation) :
+  val t = targs(f)
+  if not empty?(t):
+    print(o, "<%,>" % [t])
+  val p = parents(f)
+  if not empty?(p):
+    val combParents = string-join(p, " & ")
+    print(o, " <: %_" % [combParents])
 
 ; Note: does not use forwarding information or import list
 defmethod print (o:OutputStream, p:PackageImport) :

--- a/compiler/defs-db-serializer.stanza
+++ b/compiler/defs-db-serializer.stanza
@@ -101,6 +101,9 @@ defserializer DefsDbSerializer () :
       return-type?:opt(symbol)
     DefVarAnnotation :
       mutable?:bool
+    DefTypeAnnotation :
+      targs:tuple(symbol)
+      parents:tuple(symbol)
 
   defunion visibility (Visibility) :
     Private: enum

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -320,11 +320,36 @@ defn optional-arg? (arg:FArg<DType>) -> True|False :
 ;------------- Computing Definition Annotations -------------
 ;------------------------------------------------------------
 
+doc: \<DOC>
+Extract the Parent Types from a `deftype`
+This function assumes that the parent type for a deftype can
+only be combined with the `&` operator. The other options are
+no operator (1 parent) or no parents.
+This function is recursive.
+<DOC>
+defn extract-parent-types (parent:IExp, nm:NameMap) -> Seqable<Symbol|False> :
+  match(parent):
+    (op:IAnd):
+      for elem in [a(op), b(op)] seq-cat :
+        extract-parent-types(elem, nm)
+    (n:IVoid): []
+    (e): [stringify?(e, nm)]
+
 ;Create an annotation for a top-level expression.
 defn annotate? (iexp:IExp, nm:NameMap) -> False|DefinitionAnnotation :
   match(iexp) :
     (idefvar:IDefVar) : DefVarAnnotation(true)
     (idefval:IDef) : DefVarAnnotation(false)
+    (ideftype:IDefType|ILSDefType):
+      val targs? = for a in args(ideftype) seq:
+        stringify?(a, nm)
+      val targs = to-tuple $ filter-by<Symbol>(targs?)
+      val parents? = extract-parent-types(parent(ideftype), nm)
+      val parents = to-tuple $ filter-by<Symbol>(parents?)
+      DefTypeAnnotation(
+        targs,
+        parents
+      )
     (idefn:IDefn|IDefmethod|IDefmulti|ILSDefn|ILSDefmethod) :
       DefnAnnotation(targs, args, return-type?) where :
         val return-type? = stringify?(a2(idefn), nm)


### PR DESCRIPTION
This works for both high and lo stanza but it only extracts the type arguments and the parent types. It doesn't try to extract any of the children content yet.
