### PR TITLE
simplify symbol table extension code, always check for duplicates

### DIFF
--- a/compiler/resolver.stanza
+++ b/compiler/resolver.stanza
@@ -206,6 +206,7 @@ public defn resolve-il (packages:Tuple<IPackage|PackageExports>, env:Env) -> Res
     ;Return result
     val errors = if not empty?(error-accum) :
       ResolveErrors(to-tuple(error-accum))
+
     ResolverResult(to-tuple(ipackages*),
                    to-tuple(import-lists*),
                    init-order(),
@@ -951,37 +952,53 @@ defn SymbolTable (package-name:Symbol, base:NameMap|Tuple<Export>) :
   ;Level Table
   val table = MultilevelTable<Symbol, List<VEntry>>()
   val basetable = HashTable<Symbol, List<BaseEntry>>(List())
+
+
+    
   ; Update an entry in the basetable
   ; Assumes the resulting entry should be forwarded
-  defn update-basetable (e:VEntry, f, xs:List<BaseEntry>) -> List<BaseEntry> :
+  defn forward-base-entry (e:VEntry, f, xs:List<BaseEntry>) -> List<BaseEntry> :
     if any?({ventry(_) == e}, xs) :
       map(fn (x:BaseEntry) : if ventry(x) == e : BaseEntry(f(e), true) else : x, xs)
     else : cons(BaseEntry(f(e), true), xs)
-  ; Update symbol table entry e with function f:
-  ; Search for matching entry e, apply f. If not found, add f(e)  
-  defn forward-entry (e:VEntry, f:(VEntry -> VEntry), prefix:String|False) :
+
+  ; Forward symbol table entry to new-package under some prefix by updating its package field
+  ; Concretely: 
+  ;   Search for existing entry e, update package field if found. 
+  ;   If not found, simply update package field in e and add
+  defn forward-entry (e:VEntry, new-package:Symbol, prefix:String|False) :
+    defn fwd (e) : sub-package(e, new-package) ; Update package field
     val name* = add-prefix(prefix, name(e))
     table[name*] =
       if key?(table, name*) :
+        ; If e not found, add forwarded version
         if not contains?(table[name*], e) :
-          cons(f(e), table[name*])
-        else : ; Update matching VEntry
-          map(fn (x) : if x == e : f(x) else : x, table[name*])
-      else : List(f(e))
+          cons(fwd(e), table[name*])
+        ; Otherwise, update the matching VEntry
+        else : map(fn (x) : if x == e : fwd(x) else : x, table[name*])
+      else : List(fwd(e))
+    ; Update basetable
     if level(table) == 0 :
-      update(basetable, update-basetable{e, f, _}, name*)
-  defn add-entry (e:VEntry, prefix:String|False -- forwarded?:True|False = false) :
+      update(basetable, forward-base-entry{e, fwd, _}, name*)
+
+  ; Helper for adding VEntries to collection only if they have not
+  ;   already been added
+  defn add-unique<?E> (e:?E&Equalable, entries:List<E&Equalable>) -> List<E> :
+    if contains?(entries, e) : entries
+    else : cons(e, entries)  
+
+  ; Add a VEntry to the symbol table under its prefix
+  defn add-entry (e:VEntry, prefix:String|False) :
     val name* = add-prefix(prefix, name(e))
+    ; Update symbol table
     table[name*] =
-      if key?(table, name*) :
-        if not contains?(table[name*], e) :
-          cons(e, table[name*])
-        else :
-          table[name*]
+      if key?(table, name*) : add-unique(e, table[name*])
       else : List(e)
+    ; Update basetable
     if level(table) == 0 :
-      update(basetable, cons{BaseEntry(e,forwarded?),_}, name*)
+      update(basetable, {add-unique(BaseEntry(e, false), _)}, name*)
       false
+
   defn add-entries (es:Seqable<VEntry>) :
     do(add-entry{_, false}, es)
 
@@ -994,7 +1011,7 @@ defn SymbolTable (package-name:Symbol, base:NameMap|Tuple<Export>) :
   ; Ensures that qualified references will work.
   defn update-owner (es:Seqable<VEntry>, ptable:PrefixTable) :
     for e in es do :
-      forward-entry(e, {sub-package(_, package-name)}, ptable[name(e)])
+      forward-entry(e, package-name, ptable[name(e)])
 
   ;Initializing the symbol table
   match(base) :
@@ -1038,9 +1055,11 @@ defn SymbolTable (package-name:Symbol, base:NameMap|Tuple<Export>) :
 
 ;Represents an entry into the base table in the SymbolTable.
 ;- forwarded?: True if the entry was inherited from forwarding.
-defstruct BaseEntry :
+defstruct BaseEntry <: Equalable :
   ventry:VEntry
   forwarded?:True|False
+with:
+  equalable => true
 
 ;============================================================
 ;==================== Prefixes ==============================


### PR DESCRIPTION
This commit simplifies and corrects the code for extending and updating the symbol table. The important change is that we check for duplicate table entries when updating the base table as well.

I tested by running some manual examples, bootstrapping the compiler, and doing a full jstanza bootstrap and jitx build.