### PR TITLE
Fix string interpolation in asm-emitter

### DIFF
--- a/compiler/asm-emitter.stanza
+++ b/compiler/asm-emitter.stanza
@@ -430,7 +430,7 @@ defn gen (os:OutputStream, ins:Ins, backend:Backend) :
 
    defn #pic-set (x:Loc, y:ExMem) :
       #println(os, "  movq %_@GOTPCREL(%%rip), %_" % [#lbl(y), #imm(LongT(),x)])
-      #println(os, "  addq $_, %_" % [offset(y), #imm(LongT(), x)]) when offset(y) != 0
+      #println(os, "  addq %_, %_" % [offset(y), #imm(LongT(), x)]) when offset(y) != 0
 
    ;     Convert Instruction
    ;     -------------------


### PR DESCRIPTION
Proposing a tiny fix. My program did not execute this print statement -- rather I found it while looking broadly for "$_" usages.