### PR TITLE
Added `print` defmethod for `NoEnvVarError`

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -6151,6 +6151,9 @@ public lostanza defn unset-env (name:ref<String>) -> ref<False> :
 public defstruct NoEnvVarError <: Exception :
   name: String
 
+defmethod print (o:OutputStream, e:NoEnvVarError) :
+  print(o, "No environment variable with name '%_' found" % [name(e)])
+
 public defstruct SetEnvException <: Exception :
   name: String
   value: String


### PR DESCRIPTION
This was missing and make using `get-env!` difficult.