### PR TITLE
Jitx 6841 fix pkg cache flag

### DIFF
--- a/compiler/compiler-build-settings.stanza
+++ b/compiler/compiler-build-settings.stanza
@@ -8,7 +8,7 @@ defpackage stz/compiler-build-settings :
 
 ;Represents the full set of input options for starting
 ;a Stanza compilation job.
-;- disable-cache?: If true, then the compilation should
+;- build-from-source?: If true, then the compilation should
 ;  avoid loading packages from .pkg files as much as possible.
 public defstruct BuildSettings :
   inputs: BuildInputs with: (updater => sub-inputs)
@@ -19,7 +19,7 @@ public defstruct BuildSettings :
   external-dependencies: String|False
   pkg-dir: String|False
   pkg-cache-dir: String|False with: (updater => sub-pkg-cache-dir)
-  disable-cache?: True|False
+  build-from-source?: True|False
   optimize?: True|False
   debug?: True|False
   ccfiles: Tuple<String>

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -191,7 +191,7 @@ public defn compile (proj-manager:ProjManager,
 
     ;True if pkgs are written out, either to the pkg directory
     ;or to the cache directory.
-    val write-out-pkgs? = pkg-dir is String or pkg-cache-dir(proj-manager) is String
+    val write-out-pkgs? = pkg-dir is String
 
     ;Save optimized packages if necessary
     if write-out-pkgs? and optimize? :

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -154,7 +154,6 @@ public defn compile (proj-manager:ProjManager,
                      supported-vm-packages:Tuple<String|Symbol>,
                      output:False|String,
                      pkg-dir:False|String,
-                     pkg-cache-dir:False|String
                      backend:Backend,
                      optimize?:True|False,
                      debug?:True|False,
@@ -188,11 +187,11 @@ public defn compile (proj-manager:ProjManager,
                             flags,
                             debug?,
                             false,
-                            pkg-cache-dir)
+                            pkg-cache-dir(proj-manager))
 
     ;True if pkgs are written out, either to the pkg directory
     ;or to the cache directory.
-    val write-out-pkgs? = pkg-dir is String or pkg-cache-dir is String
+    val write-out-pkgs? = pkg-dir is String or pkg-cache-dir(proj-manager) is String
 
     ;Save optimized packages if necessary
     if write-out-pkgs? and optimize? :

--- a/compiler/compiler-main.stanza
+++ b/compiler/compiler-main.stanza
@@ -154,6 +154,7 @@ public defn compile (proj-manager:ProjManager,
                      supported-vm-packages:Tuple<String|Symbol>,
                      output:False|String,
                      pkg-dir:False|String,
+                     pkg-cache-dir:False|String
                      backend:Backend,
                      optimize?:True|False,
                      debug?:True|False,
@@ -180,19 +181,18 @@ public defn compile (proj-manager:ProjManager,
       defmethod verbose? (this) : verbose?
       defmethod macroexpander (this) : macroexpander
 
-    ;Create pkg saver for saving output .pgk files.
-    val cache-dir = pkg-cache-dir(proj-manager)
+    ;Create pkg saver for saving output .pkg files.
     val pkgsaver = PkgSaver(auxfile,
                             pkgstamps(result),
                             pkg-dir,
                             flags,
                             debug?,
                             false,
-                            cache-dir)
-    
+                            pkg-cache-dir)
+
     ;True if pkgs are written out, either to the pkg directory
     ;or to the cache directory.
-    val write-out-pkgs? = pkg-dir is String or cache-dir is String    
+    val write-out-pkgs? = pkg-dir is String or pkg-cache-dir is String
 
     ;Save optimized packages if necessary
     if write-out-pkgs? and optimize? :
@@ -249,7 +249,7 @@ public defn compile (proj-manager:ProjManager,
     compile(lower-optimized(epackages), debug?)
 
   ;- pkgsaver: False if we not need to write out any .pkg files to disk (either
-  ;  to pkg dir or to pkg cache.). 
+  ;  to pkg dir or to pkg cache.).
   defn compile-vmpackages (pkgsaver:PkgSaver|False,
                            packages:Tuple<VMPackage|StdPkg>,
                            bindings:Bindings|False,

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -244,7 +244,7 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       setup-system-flags(settings*)
       val proj-params = ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, disable-cache?(settings*), pkg-cache-dir(settings*))
       val proj-manager = ProjManager(proj, proj-params, auxfile)
-      val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*), pkg-cache-dir(settings*)
+      val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
                                 backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,
                                 macro-plugins(settings*), inputs(settings) is BuildTarget)
       save(auxfile)

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -187,7 +187,7 @@ public defn dependencies (settings:BuildSettings) -> DependencyResult :
       (f:False) : OUTPUT-PLATFORM
 
   defn compute-dependencies (proj:ProjFile, settings:BuildSettings) :
-    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false, disable-cache?(settings))
+    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false, disable-cache?(settings), pkg-cache-dir(settings))
     val proj-manager = ProjManager(proj, params, AuxFile())
     val macroexpander = StanzaMacroexpander(false, proj-manager, macro-plugins(settings))
     dependencies $ new FrontEndInputs :
@@ -242,9 +242,9 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       println("Build target %~ is already up-to-date." % [build-target?(settings*)])
     else :
       setup-system-flags(settings*)
-      val proj-params = ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, disable-cache?(settings))
+      val proj-params = ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, disable-cache?(settings*), pkg-cache-dir(settings*))
       val proj-manager = ProjManager(proj, proj-params, auxfile)
-      val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
+      val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*), pkg-cache-dir(settings*)
                                 backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,
                                 macro-plugins(settings*), inputs(settings) is BuildTarget)
       save(auxfile)

--- a/compiler/compiler.stanza
+++ b/compiler/compiler.stanza
@@ -106,7 +106,7 @@ defn compute-build-settings (projenv:StandardProjEnv,
         build-ext-deps,
         build-pkg-dir,
         pkg-cache-dir*,
-        disable-cache?(settings)
+        build-from-source?(settings)
         build-optimization,
         build-debug,
         build-ccfiles,
@@ -187,7 +187,7 @@ public defn dependencies (settings:BuildSettings) -> DependencyResult :
       (f:False) : OUTPUT-PLATFORM
 
   defn compute-dependencies (proj:ProjFile, settings:BuildSettings) :
-    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false, disable-cache?(settings), pkg-cache-dir(settings))
+    val params = ProjParams(compiler-flags(), optimize?(settings), debug?(settings), false, build-from-source?(settings), pkg-cache-dir(settings))
     val proj-manager = ProjManager(proj, params, AuxFile())
     val macroexpander = StanzaMacroexpander(false, proj-manager, macro-plugins(settings))
     dependencies $ new FrontEndInputs :
@@ -242,7 +242,7 @@ public defn compile (settings:BuildSettings, system:System, verbose?:True|False)
       println("Build target %~ is already up-to-date." % [build-target?(settings*)])
     else :
       setup-system-flags(settings*)
-      val proj-params = ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, disable-cache?(settings*), pkg-cache-dir(settings*))
+      val proj-params = ProjParams(compiler-flags(), optimize?(settings*), debug?(settings*), false, build-from-source?(settings), pkg-cache-dir(settings*))
       val proj-manager = ProjManager(proj, proj-params, auxfile)
       val comp-result = compile(proj-manager, auxfile, build-inputs!(settings*), vm-packages(settings*), asm?(settings*), pkg-dir(settings*),
                                 backend(platform(settings*) as Symbol), optimize?(settings*), debug?(settings*), verbose?,

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -95,7 +95,7 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
     false,                                  ;external dependencies
     false,                                  ;pkg-dir
     false,                                  ;pkg-cache-dir
-    true,                                   ;disable-cache?
+    true,                                   ;build-from-source?
     optimize?(input),                       ;optimize?
     false,                                  ;debug?
     [],                                     ;ccfiles

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -226,7 +226,7 @@ val COMMON-STANZA-FLAGS = [
     "Requests the compiler to output the .pkg files. The name of the folder to store the output .pkg files can be optionally provided.")
   Flag("pkg-cache", OneFlag, OptionalFlag,
     "Directory for caching compiled .pkg files.")
-  Flag("disable-cache", ZeroFlag, OptionalFlag,
+  Flag("build-from-source", ZeroFlag, OptionalFlag,
     "If given, then packages will always be loaded from their source files instead of their .pkg files if \
      their source files are available.")
   Flag("optimize", ZeroFlag, OptionalFlag,
@@ -334,7 +334,7 @@ defn compile-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "disable-cache")
+        flag?(cmd-args, "build-from-source")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -351,7 +351,7 @@ defn compile-command () :
   ;Command
   Command("compile",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names.",
-          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "disable-cache" "optimize" "debug" "ccfiles" "ccflags" "flags"
+          common-stanza-flags(["o" "s" "pkg" "pkg-cache" "build-from-source" "optimize" "debug" "ccfiles" "ccflags" "flags"
                                "verbose" "supported-vm-packages" "platform" "external-dependencies" "macros" "link" "timing-log"]),
           compile-msg, false, verify-args, intercept-no-match-exceptions(compile-action))
 
@@ -384,7 +384,7 @@ defn build-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "disable-cache")
+        flag?(cmd-args, "build-from-source")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         []
@@ -401,7 +401,7 @@ defn build-command () :
   ;Command definition
   Command("build",
           ZeroOrOneArg, "the name of the build target. If not supplied, the default build target is 'main'.",
-          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
+          common-stanza-flags(["s" "o" "external-dependencies" "pkg" "pkg-cache" "build-from-source" "flags" "optimize" "debug" "verbose" "ccflags" "macros" "link" "timing-log"]),
           build-msg, false, verify-args, intercept-no-match-exceptions(build))
 
 ;============================================================
@@ -521,7 +521,7 @@ defn compile-test-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "disable-cache")
+        flag?(cmd-args, "build-from-source")
         flag?(cmd-args, "optimize")
         flag?(cmd-args, "debug")
         get?(cmd-args, "ccfiles", [])
@@ -536,7 +536,7 @@ defn compile-test-command () :
   ;Command definition
   Command("compile-test",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing tests.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "build-from-source" "ccfiles" "ccflags" "flags" "optimize" "debug" "verbose"
                                "macros" "link" "timing-log"])
           compile-test-msg, false, verify-args, intercept-no-match-exceptions(compile-test))
 
@@ -587,7 +587,7 @@ defn compile-macros-command () :
         get?(cmd-args, "external-dependencies", false)
         pkg-dir
         get?(cmd-args, "pkg-cache", false)
-        flag?(cmd-args, "disable-cache")
+        flag?(cmd-args, "build-from-source")
         flag?(cmd-args, "optimize")
         false
         get?(cmd-args, "ccfiles", [])
@@ -602,7 +602,7 @@ defn compile-macros-command () :
   ;Command definition
   Command("compile-macros",
           AtLeastOneArg, "the .stanza/.proj input files or Stanza package names containing macros.",
-          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "disable-cache" "ccfiles" "ccflags" "flags" "optimize" "verbose"
+          common-stanza-flags(["platform" "s" "o" "external-dependencies" "pkg" "pkg-cache" "build-from-source" "ccfiles" "ccflags" "flags" "optimize" "verbose"
                                "macros" "timing-log"])
           compile-macros-msg, false, verify-args, intercept-no-match-exceptions(compile-macro))
 
@@ -713,7 +713,7 @@ defn repl-command () :
       "The terminal style (simple/edit) to use for the REPL. If not provided, defaults to 'edit' if available \
        on the current platform.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("disable-cache")
+    common-stanza-flag("build-from-source")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
     Flag("-", AllRemainingFlag, OptionalFlag,
@@ -766,7 +766,7 @@ defn repl-command () :
              terminal-style,
              get?(cmd-args, "macros", [])
              get?(cmd-args, "pkg-cache", false)
-             flag?(cmd-args, "disable-cache"))
+             flag?(cmd-args, "build-from-source"))
 
     ;Confirm exit
     if flag?(cmd-args, "confirm-before-exit") :
@@ -802,7 +802,7 @@ defn run-command () :
     Flag("flags", ZeroOrMoreFlag, OptionalFlag,
       "The set of compile-time flags to be set before beginning execution.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("disable-cache")
+    common-stanza-flag("build-from-source")
     common-stanza-flag("verbose")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")
@@ -842,7 +842,7 @@ defn run-command () :
         run-in-repl(args(cmd-args),
                     get?(cmd-args, "macros", []),
                     get?(cmd-args, "pkg-cache", false)
-                    flag?(cmd-args, "disable-cache"))
+                    flag?(cmd-args, "build-from-source"))
 
   ;Command definition
   Command(
@@ -874,7 +874,7 @@ defn run-test-command () :
     Flag("log", OneFlag, OptionalFlag,
       "The directory to output the test results to.")
     common-stanza-flag("pkg-cache")
-    common-stanza-flag("disable-cache")
+    common-stanza-flag("build-from-source")
     common-stanza-flag("macros")
     common-stanza-flag("timing-log")]
 
@@ -927,7 +927,7 @@ defn run-test-command () :
       run-in-repl(new-args,
                   get?(cmd-args, "macros", []),
                   get?(cmd-args, "pkg-cache", false),
-                  flag?(cmd-args, "disable-cache"))
+                  flag?(cmd-args, "build-from-source"))
 
   ;Command definition
   Command("run-test",
@@ -990,7 +990,7 @@ defn analyze-dependencies-command () :
         false
         pkg-dir
         false
-        flag?(cmd-args, "disable-cache")
+        flag?(cmd-args, "build-from-source")
         flag?(cmd-args, "optimize")
         false
         []
@@ -1006,7 +1006,7 @@ defn analyze-dependencies-command () :
   Command("analyze-dependencies",
           AtLeastOneArg, "the .stanza/.proj inputs or Stanza package names to analyze.",
           to-tuple $ cat(new-flags, common-stanza-flags(["platform" "flags" "supported-vm-packages" "optimize"
-                                                         "macros" "timing-log" "disable-cache"]))
+                                                         "macros" "timing-log" "build-from-source"]))
           analyze-msg, false, verify-args, intercept-no-match-exceptions(analyze-dependencies-action))
 
 ;============================================================

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -274,7 +274,7 @@ defn ensure-proper-verbose-level! (cmd-args:CommandArgs) :
     val setting:Maybe<String> = cmd-args["verbose"]
     if not empty?(setting) :
       match(to-int(value!(setting))) :
-        (v:Int) : 
+        (v:Int) :
           if v < 1 or v > 10 :
             throw(ArgParseError("The '-verbose' flag requires an integer between 1 and 10."))
         (f:False) :
@@ -947,7 +947,7 @@ defn analyze-dependencies-command () :
     Flag("graphviz", OneFlag, OptionalFlag,
       "If given, outputs the dependencies using the GraphViz format to the given file.")
     Flag("build-target", ZeroFlag, OptionalFlag,
-      "If given, then the argument is interpreted to be the name of a build target instead of a Stanza package.")    
+      "If given, then the argument is interpreted to be the name of a build target instead of a Stanza package.")
     Flag("pkg", ZeroOrOneFlag, OptionalFlag,
       "If provided, search the given folder for .pkg files.")]
 

--- a/compiler/pkg-saver.stanza
+++ b/compiler/pkg-saver.stanza
@@ -45,7 +45,7 @@ public defn PkgSaver (auxfile:AuxFile,
                       flags:Tuple<Symbol>,
                       debug?:True|False,
                       repl?:True|False,
-                      cache-dir:String|False) :
+                      cache-dir:String) :
 
   ;Table of PackageStamps for easy retrieval.
   val pkgstamp-table = to-hashtable(package, package-stamps)
@@ -99,7 +99,7 @@ public defn PkgSaver (auxfile:AuxFile,
     defmethod cache (this, pkg:Pkg) :
       if origin(pkg) != FromSource :
         fatal("Cannot cache a .pkg that did not originate from source file.")
-      val params = CacheParams(flags, cache-dir as String, repl?, debug?, pkg-source(pkg))
+      val params = CacheParams(flags, cache-dir, repl?, debug?, pkg-source(pkg))
       val filename = save-package-to-cache(params, pkg)
       val filestamp = filestamp(filename)
       save-aux-record(pkg, filestamp)
@@ -107,7 +107,7 @@ public defn PkgSaver (auxfile:AuxFile,
     ;Save the given pkg to the appropriate places.
     defmethod save-when-appropriate (this, pkg:Pkg) :
       ;Save to cache if pkg was compiled from source.
-      if cache-dir is String and origin(pkg) == FromSource :
+      if origin(pkg) == FromSource :
         cache(this, pkg)
       ;Save to pkgdir if pkg was not from explicit pkg.
       if dir is String and origin(pkg) != FromPkg :

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -83,7 +83,7 @@ public defmulti find-macro-build-target (l:ProjManager, filename:String) -> Symb
 public defmulti dynamic-libraries (l:ProjManager, packages:Tuple<Symbol>) -> RequiredLibraries
 
 ;Return the pkg cache directory if one is supplied.
-public defmulti pkg-cache-dir (l:ProjManager) -> String|False
+public defmulti pkg-cache-dir (l:ProjManager) -> String
 
 ;Represents the required libraries and folders for a set of Stanza packages.
 public defstruct RequiredLibraries :
@@ -140,15 +140,14 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
   ;Unless the cache is explicitly disabled, the pkg-cache
   ;directory is found in the .proj file if one is given,
   ;or in the system installation folder by default.
-  val pkg-cache-dir =
-    if not disable-cache?(params) :
-      ; First priority: command-line arg
-      match(cache-dir(params):String) : cache-dir(params)
-      else :
-        ; Second priority: .proj file
-        match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj)
-        ; Third priority: default system directory
-        else : system-filepath(StanzaPkgCacheDir)
+  val cache-dir:String =
+    ; First priority: command-line arg
+    match(cache-dir(params):String) : cache-dir(params) as String
+    else :
+      ; Second priority: .proj file
+      match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj) as String
+      ; Third priority: default system directory
+      else : system-filepath(StanzaPkgCacheDir)
 
   ;Find the source file that contains the package.
   defn source-file? (name:Symbol) -> String|False :
@@ -174,8 +173,8 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
     ;Load the pkg file for the package.
     ;Note: If there is no source file present, then we skip looking in the cache
     ;entirely.
-    val cache-params = match(pkg-cache-dir:String, src-path:String) :
-      CacheParams(flags(params), pkg-cache-dir, in-repl?(params), debug?(params), src-path)
+    val cache-params = match(src-path:String) :
+      CacheParams(flags(params), cache-dir, in-repl?(params), debug?(params), src-path)
     val pkg-file = find-pkg(name, optimize?(params), cache-params = cache-params)
 
     ;Determine whether the pkg is up-to-date and should be read from.
@@ -265,7 +264,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
       ;Return bundled result
       RequiredLibraries(package-libs, folders)
 
-    defmethod pkg-cache-dir (this) : pkg-cache-dir
+    defmethod pkg-cache-dir (this) : cache-dir
 
 ;============================================================
 ;================ Pkg file Up-to-date =======================
@@ -277,7 +276,8 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
 defn pkg-up-to-date? (params:ProjParams, auxfile:AuxFile,
                       name:Symbol, pkg-file:PkgFile, src-path:String) -> True|False :
 
-  if file-exists?(src-path) :
+  if build-from-source?(params) : false ; Always consider .pkg dirty
+  else if file-exists?(src-path) :
 
     vprintln("Check whether package %~ is up-to-date." % [name])
 
@@ -312,8 +312,8 @@ public defstruct ProjParams :
   optimize?: True|False
   debug?: True|False
   in-repl?: True|False
-  disable-cache? : True|False
-  cache-dir:String|False
+  build-from-source?: True|False
+  cache-dir: String|False
 
 ;============================================================
 ;===================== Package Tree =========================

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -140,10 +140,15 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
   ;Unless the cache is explicitly disabled, the pkg-cache
   ;directory is found in the .proj file if one is given,
   ;or in the system installation folder by default.
-  val pkg-cache-dir = 
-    if not disable-cache?(params) : 
-      match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj)
-      else : system-filepath(StanzaPkgCacheDir) 
+  val pkg-cache-dir =
+    if not disable-cache?(params) :
+      ; First priority: command-line arg
+      match(cache-dir(params):String) : cache-dir(params)
+      else :
+        ; Second priority: .proj file
+        match(pkg-cache-dir(proj):String) : pkg-cache-dir(proj)
+        ; Third priority: default system directory
+        else : system-filepath(StanzaPkgCacheDir)
 
   ;Find the source file that contains the package.
   defn source-file? (name:Symbol) -> String|False :
@@ -175,17 +180,17 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
 
     ;Determine whether the pkg is up-to-date and should be read from.
     val read-pkg? = match(pkg-file, src-path) :
-    
+
       ;If we found a .pkg file and a corresponding source file, then
       ;check with the auxfile to see whether the .pkg file is up-to-date.
       (pkg-file:PkgFile, src-path:String) :
         pkg-up-to-date?(params, auxfile, name, pkg-file, src-path)
-            
+
       ;If there is no corresponding source file, then read from the
       ;.pkg file only if it is explicitly from the pkg dir. Do not
       ;consider .pkgs from the pkg cache.
       (pkg-file:PkgDir, src-path:False) : true
-      
+
       ;Otherwise do not read from the .pkg file.
       (pkg-file, src-path) : false
 
@@ -230,10 +235,10 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
   new ProjManager :
     defmethod find-package (this, name:Symbol) :
       find-package(name)
-      
+
     defmethod conditional-imports (this, packages:Seqable<Symbol>) :
       conditional-imports(packages)
-      
+
     defmethod find-syntax-packages (this, names:Tuple<Symbol>) :
       find-syntax-packages(names)
 
@@ -260,8 +265,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
       ;Return bundled result
       RequiredLibraries(package-libs, folders)
 
-    defmethod pkg-cache-dir (this) :
-      pkg-cache-dir
+    defmethod pkg-cache-dir (this) : pkg-cache-dir
 
 ;============================================================
 ;================ Pkg file Up-to-date =======================
@@ -272,9 +276,9 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
 ;desired project configuration.
 defn pkg-up-to-date? (params:ProjParams, auxfile:AuxFile,
                       name:Symbol, pkg-file:PkgFile, src-path:String) -> True|False :
-  
+
   if file-exists?(src-path) and not disable-cache?(params) :
-  
+
     vprintln("Check whether package %~ is up-to-date." % [name])
 
     ;Create the PkgRecord to look for in the aux file.
@@ -302,13 +306,14 @@ defn pkg-up-to-date? (params:ProjParams, auxfile:AuxFile,
 ;============================================================
 
 ;Represents the configuration to use under which to look for
-;.pkg files.
+;.pkg files; these settings can override the .proj file itself.
 public defstruct ProjParams :
   flags: Tuple<Symbol>
   optimize?: True|False
   debug?: True|False
   in-repl?: True|False
   disable-cache? : True|False
+  cache-dir:String|False
 
 ;============================================================
 ;===================== Package Tree =========================

--- a/compiler/proj-manager.stanza
+++ b/compiler/proj-manager.stanza
@@ -277,7 +277,7 @@ public defn ProjManager (proj:ProjFile, params:ProjParams, auxfile:AuxFile) :
 defn pkg-up-to-date? (params:ProjParams, auxfile:AuxFile,
                       name:Symbol, pkg-file:PkgFile, src-path:String) -> True|False :
 
-  if file-exists?(src-path) and not disable-cache?(params) :
+  if file-exists?(src-path) :
 
     vprintln("Check whether package %~ is up-to-date." % [name])
 

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -309,7 +309,7 @@ public defn REPL (macro-plugins:Tuple<String>,
   defn proj-manager () :
     within log-time(REPL-PROJ-MANAGER) :
       val proj = read-proj-files(proj-files, OUTPUT-PLATFORM, `dynamic, StandardProjEnv())
-      val params = ProjParams(compiler-flags, false, false, true, disable-cache?)
+      val params = ProjParams(compiler-flags, false, false, true, disable-cache?, pkg-cache-dir)
       ProjManager(proj, params, auxfile)
 
   add-all(proj-files, default-proj-files())

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -281,7 +281,7 @@ defmulti shutdown (repl:REPL) -> False
 
 public defn REPL (macro-plugins:Tuple<String>,
                   pkg-cache-dir:String|False,
-                  disable-cache?:True|False) :
+                  build-from-source?:True|False) :
   ;============================================================
   ;===================== REPL State ===========================
   ;============================================================
@@ -309,7 +309,7 @@ public defn REPL (macro-plugins:Tuple<String>,
   defn proj-manager () :
     within log-time(REPL-PROJ-MANAGER) :
       val proj = read-proj-files(proj-files, OUTPUT-PLATFORM, `dynamic, StandardProjEnv())
-      val params = ProjParams(compiler-flags, false, false, true, disable-cache?, pkg-cache-dir)
+      val params = ProjParams(compiler-flags, false, false, true, build-from-source?, pkg-cache-dir)
       ProjManager(proj, params, auxfile)
 
   add-all(proj-files, default-proj-files())
@@ -504,8 +504,7 @@ public defn REPL (macro-plugins:Tuple<String>,
             vprintln("REPL: Skipping VMPackage compilation of %_. Loaded directly from .pkg." % [name(p)])
             vmp(p)
 
-      ;Save the auxiliary file if caching is enabled.
-      save(auxfile) when /pkg-cache-dir(proj-manager) is String
+      save(auxfile)
 
       ;Return the compiled VMPackages.
       vmpackages
@@ -1006,8 +1005,8 @@ public defn repl (args:Tuple<String>,
                   style:TerminalStyle,
                   macro-plugins:Tuple<String>,
                   pkg-cache-dir:String|False,
-                  disable-cache?:True|False) :
-  val repl = REPL(macro-plugins, pkg-cache-dir, disable-cache?)
+                  build-from-source?:True|False) :
+  val repl = REPL(macro-plugins, pkg-cache-dir, build-from-source?)
 
   ;Create a LoadExp expression out of the command line
   ;arguments. And execute them in the REPL.
@@ -1067,9 +1066,9 @@ public defn repl () :
 public defn run-in-repl (args:Tuple<String>,
                          macro-plugins:Tuple<String>,
                          pkg-cache-dir:String|False,
-                         disable-cache?:True|False) :
+                         build-from-source?:True|False) :
   val repl = within log-time(REPL-CREATION) :
-    REPL(macro-plugins, pkg-cache-dir, disable-cache?)
+    REPL(macro-plugins, pkg-cache-dir, build-from-source?)
   try:
     within log-time(REPL-EXP-EVALUATION) :
       eval-exp(repl, make-load-exp(args, false))

--- a/compiler/repl.stanza
+++ b/compiler/repl.stanza
@@ -478,15 +478,13 @@ public defn REPL (macro-plugins:Tuple<String>,
     within log-time(REPL-LOWERING-AND-COMPILATION) :
     
       ;Create the PkgSaver to cache pkg files when appropriate.
-      val cache-dir = match(pkg-cache-dir:String) : pkg-cache-dir
-                      else : /pkg-cache-dir(proj-manager)
       val pkgsaver = PkgSaver(auxfile,
                               pkgstamps(result),
                               false,
                               compiler-flags,
                               false,
                               true,
-                              cache-dir)
+                              /pkg-cache-dir(proj-manager))
 
       ;Compile the EPackages into VMPackages.
       val vmpackages = for p in packages(result) map :
@@ -507,7 +505,7 @@ public defn REPL (macro-plugins:Tuple<String>,
             vmp(p)
 
       ;Save the auxiliary file if caching is enabled.
-      save(auxfile) when cache-dir is String
+      save(auxfile) when /pkg-cache-dir(proj-manager) is String
 
       ;Return the compiled VMPackages.
       vmpackages


### PR DESCRIPTION
This ensures that the `-pkg-cache` flag takes precedence over the corresponding field in a .proj file.

To do so we extend the `ProjParams` struct with an additional field: the struct represents any command line info that might override .proj file behavior. The `ProjManager` is responsible for finding .pkg files; it combines all of the directory parameters and a possible `-disable-cache` flag to compute the actual value (of type `String|False`).
