### PR TITLE
Fix detection of stopped processes

### DIFF
--- a/runtime/process-posix.c
+++ b/runtime/process-posix.c
@@ -105,7 +105,7 @@ static void register_child_process (
   child->fin = fin;
   child->fout = fout;
   child->ferr = ferr;
-  child->pstatus = st; //;&(st->status_code);
+  child->pstatus = st;
 
   // Store child in ChildProcessList
   add_child_process(child);

--- a/runtime/process.h
+++ b/runtime/process.h
@@ -7,6 +7,7 @@
 //- status_code: Holds the POSIX status code of the process as communicated by
 //  the SIGCHILD signal.
 typedef struct ProcessStatus {
+  int code_set;
   stz_int status_code;
 } ProcessStatus;
 


### PR DESCRIPTION
Since `WIFSTOPPED(-1)` is true (at least on my OSX machine), I add a flag `code_set` the `ProcessStatus` struct indicating whether or not the status code was set by `waitpid` or not.