### PR TITLE
don't fail in the presence of duplicate packages

### DIFF
--- a/compiler/front-end.stanza
+++ b/compiler/front-end.stanza
@@ -614,7 +614,8 @@ defn FrontEnd (sys:FrontEndInputs) -> FrontEnd :
       if add(added-set, name(p)) : true
       else : add(duplicates, name(p))
     if not empty?(duplicates) :
-      throw(DuplicatePackages(to-tuple(duplicates)))
+      vprintln("Warning: dropping duplicate packages %_" % [to-tuple(duplicates)])
+      add(errors, DuplicatePackages(to-tuple(duplicates)))
     ps*
 
   defn check-already-loaded (ps:Seqable<IPackage|Pkg>, errors:Vector<Exception>) -> Tuple<IPackage|Pkg> :

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -1119,12 +1119,14 @@ defn defs-db-command () :
         get?(cmd-args, "macros", []))                 ;macro-plugin
 
     ;Launch!
-    run-with-timing-log(main, cmd-args)
+    within run-with-timing-log(cmd-args) :
+      within run-with-verbose-flag(cmd-args) :
+        main()
 
   ;Command definition
   Command("definitions-database",
           AtLeastOneArg, "the .proj files to use to generate definitions for.",
-          to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "optimize", "macros", "timing-log"])),
+          to-tuple $ cat(new-flags, common-stanza-flags(["platform", "flags", "optimize", "verbose", "macros", "timing-log"])),
           defs-db-msg, false, verify-args, intercept-no-match-exceptions(defs-db-action))
 
 


### PR DESCRIPTION
Two small changes to `definitions-database`:
1. command should not fail if there are duplicate packages (compilation will still fail)
2. add `-verbose` flag