### PR TITLE
Partial definitions-database rebuild

### DIFF
--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -42,6 +42,7 @@ public defstruct DefsDbInput :
   optimize?: True|False
   merge-db?: String|False
   macro-plugins: Tuple<String>
+  stanza-files: False|Tuple<String>
 with :
   printer => true
 
@@ -80,9 +81,16 @@ public defn defs-db (input:DefsDbInput, filename:String) :
 ;object summarizing the results.
 
 protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResult :
+
   ;Read all listed packages from given project files
   val proj-file = read-proj-files(proj-files(input), platform(input), default-link-type(false), StandardProjEnv())
-  val stanza-files = all-package-files(proj-file)
+  val stanza-files = ;all-package-files(proj-file)
+    match(stanza-files(input)) :
+      (fs:Tuple)  : fs
+      (otherwise) : all-package-files(proj-file) ; default to all .stanza files
+
+  ;println(".stanza files: %_" % [stanza-files])
+
   val proj-and-stanza-files = to-tuple $
     cat(proj-files(input), stanza-files)
 

--- a/compiler/defs-db.stanza
+++ b/compiler/defs-db.stanza
@@ -84,12 +84,10 @@ protected-when(TESTING) defn analyze-input (input:DefsDbInput) -> DependencyResu
 
   ;Read all listed packages from given project files
   val proj-file = read-proj-files(proj-files(input), platform(input), default-link-type(false), StandardProjEnv())
-  val stanza-files = ;all-package-files(proj-file)
+  val stanza-files =
     match(stanza-files(input)) :
       (fs:Tuple)  : fs
       (otherwise) : all-package-files(proj-file) ; default to all .stanza files
-
-  ;println(".stanza files: %_" % [stanza-files])
 
   val proj-and-stanza-files = to-tuple $
     cat(proj-files(input), stanza-files)

--- a/compiler/main.stanza
+++ b/compiler/main.stanza
@@ -1089,7 +1089,10 @@ defn defs-db-command () :
       "The name of the output definitions file.")
     Flag("merge-with", OneFlag, OptionalFlag,
       "The path to an existing definitions file, with which to merge \
-       the newly generated definitions.")]
+       the newly generated definitions.")
+    Flag("stanza-files", AtLeastOneFlag, OptionalFlag,
+      "The set of .stanza files from which to build the \
+        definitions database")]
 
   ;Verify arguments
   defn verify-args (cmd-args:CommandArgs) :
@@ -1116,7 +1119,8 @@ defn defs-db-command () :
         map(to-symbol, get?(cmd-args, "flags", [])),  ;flags
         flag?(cmd-args, "optimize")                   ;optimize?
         get?(cmd-args, "merge-with", false)           ;merge-db?
-        get?(cmd-args, "macros", []))                 ;macro-plugin
+        get?(cmd-args, "macros", [])                 ;macro-plugin
+        get?(cmd-args, "stanza-files", false))
 
     ;Launch!
     within run-with-timing-log(cmd-args) :


### PR DESCRIPTION
This adds a new flag to the `definitions-database` command: `stanza definitions-database stanza.proj -stanza-files a.stanza b.stanza` will build a database for only the specified files.

This will enable faster language server updates, as this feature, along with database merging, allows the language server to update only the parts of the database relevant to the files being edited.