### PR TITLE
jb/retained heap analysis

### DIFF
--- a/compiler/codegen.stanza
+++ b/compiler/codegen.stanza
@@ -334,6 +334,7 @@ public defn compile-entry-function (emitter:CodeEmitter, stubs:AsmStubs) :
                                #label(safepoint-table)        ;safepoint-table:ptr<?>
                                #label(debug-table)            ;debug-table:ptr<?>
                                #label(local-var-table)        ;local-var-table:ptr<?>
+                               #long()                        ;heap-dominator-tree:ptr<?>
                                #label(class-table)            ;class-table:ptr<?>
                                #label(global-root-table)      ;global-root-table:ptr<GlobalRoots>
                                #label(stackmap-table)         ;stackmap-table:ptr<?>

--- a/compiler/vm-structures.stanza
+++ b/compiler/vm-structures.stanza
@@ -31,6 +31,7 @@ public lostanza deftype VMState :
   var safepoint-table: ptr<?>      ;(Permanent State)
   var debug-table: ptr<?>          ;(Permanent State)
   var local-var-table: ptr<?>      ;(Permanent State)
+  var heap-dominator-tree: ptr<?>  ;(Variable State)
   var class-table: ptr<?>          ;(Permanent State)
   ;Interpreted Mode Tables
   var instructions: ptr<byte>      ;(Permanent State)

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -214,31 +214,83 @@ protected lostanza deftype ArrayRecord :
 ;are used only in compiled mode.
 ;Permanent state changes in-between each code load.
 ;Variable state changes in-between each boundary change.
-protected lostanza deftype VMState :
-  ;Compiled and Interpreted Mode
-  global-offsets: ptr<long>   ;(Permanent State)
-  global-mem: ptr<byte>       ;(Permanent State)
-  var sig-handler: long       ;(Permanent State)
-  var current-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
-  var stepping-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
-  const-table: ptr<long>      ;(Permanent State)
-  const-mem: ptr<byte>        ;(Permanent State)
-  data-offsets: ptr<int>      ;(Permanent State)
-  data-mem: ptr<byte>         ;(Permanent State)
-  code-offsets: ptr<int>      ;(Permanent State)
-  registers: ptr<long>        ;(Permanent State)
-  system-registers: ptr<long> ;(Permanent State)
-  var heap: Heap              ;(Variable State)
-  safepoint-table: ptr<?>     ;(Variable State)
-  debug-table: ptr<?>         ;(Variable State)
-  local-var-table: ptr<?>     ;(Variable State)
-  ;Compiled Mode Tables
-  class-table: ptr<ClassDescriptor>
-  global-root-table: ptr<GlobalRoots>
-  stackmap-table: ptr<ptr<StackMap>>
-  stack-trace-table: ptr<StackTraceTable>
-  extern-table: ptr<ExternTable>
-  extern-defn-table: ptr<ExternDefnTable>
+#if-defined(BOOTSTRAP) :
+
+  protected lostanza deftype VMState :
+    ;Compiled and Interpreted Mode
+    global-offsets: ptr<long>   ;(Permanent State)
+    global-mem: ptr<byte>       ;(Permanent State)
+    var sig-handler: long       ;(Permanent State)
+    var current-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
+    var stepping-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
+    const-table: ptr<long>      ;(Permanent State)
+    const-mem: ptr<byte>        ;(Permanent State)
+    data-offsets: ptr<int>      ;(Permanent State)
+    data-mem: ptr<byte>         ;(Permanent State)
+    code-offsets: ptr<int>      ;(Permanent State)
+    registers: ptr<long>        ;(Permanent State)
+    system-registers: ptr<long> ;(Permanent State)
+    var heap: Heap              ;(Variable State)
+    safepoint-table: ptr<?>     ;(Variable State)
+    debug-table: ptr<?>         ;(Variable State)
+    local-var-table: ptr<?>     ;(Variable State)
+    ;Compiled Mode Tables
+    class-table: ptr<ClassDescriptor>
+    global-root-table: ptr<GlobalRoots>
+    stackmap-table: ptr<ptr<StackMap>>
+    stack-trace-table: ptr<StackTraceTable>
+    extern-table: ptr<ExternTable>
+    extern-defn-table: ptr<ExternDefnTable>
+
+  lostanza defn initialize-dominator-tree () -> ref<False> :
+    return false
+
+#else:
+
+  protected lostanza deftype HeapDominator :
+    var roots : ptr<LSLongVector>
+    var sizes : ptr<LSLongVector>
+    var addrs : ptr<LSLongVector>
+    var offs  : ptr<LSLongVector>
+    var heap  : ptr<LSLongVector>
+
+  protected lostanza deftype VMState :
+    ;Compiled and Interpreted Mode
+    global-offsets: ptr<long>   ;(Permanent State)
+    global-mem: ptr<byte>       ;(Permanent State)
+    var sig-handler: long       ;(Permanent State)
+    var current-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
+    var stepping-coroutine-ptr: ptr<long> ;[TODO] Change to long to represent reference.
+    const-table: ptr<long>      ;(Permanent State)
+    const-mem: ptr<byte>        ;(Permanent State)
+    data-offsets: ptr<int>      ;(Permanent State)
+    data-mem: ptr<byte>         ;(Permanent State)
+    code-offsets: ptr<int>      ;(Permanent State)
+    registers: ptr<long>        ;(Permanent State)
+    system-registers: ptr<long> ;(Permanent State)
+    var heap: Heap              ;(Variable State)
+    safepoint-table: ptr<?>     ;(Variable State)
+    debug-table: ptr<?>         ;(Variable State)
+    local-var-table: ptr<?>     ;(Variable State)
+    var dom: ptr<HeapDominator> ;(Variable State)
+    ;Compiled Mode Tables
+    class-table: ptr<ClassDescriptor>
+    global-root-table: ptr<GlobalRoots>
+    stackmap-table: ptr<ptr<StackMap>>
+    stack-trace-table: ptr<StackTraceTable>
+    extern-table: ptr<ExternTable>
+    extern-defn-table: ptr<ExternDefnTable>
+
+  lostanza defn initialize-dominator-tree () -> ref<False> :
+    val vms:ptr<core/VMState> = call-prim flush-vm()
+    val dom = (call-c clib/malloc(sizeof(HeapDominator))) as ptr<HeapDominator>
+    dom.roots = LSLongVector()
+    dom.sizes = LSLongVector()
+    dom.addrs = LSLongVector()
+    dom.offs  = LSLongVector()
+    dom.heap  = LSLongVector()
+    vms.dom   = dom
+    return false
 
 lostanza deftype ExternTable :
   length: long
@@ -1614,9 +1666,9 @@ lostanza defn iterate-roots (f:ptr<((ptr<long>, ptr<VMState>) -> ref<False>)>,
   return [vms.heap.iterate-roots](f, vms)
 
 ;Call f on all references stored in the object pointed to by p.
-lostanza defn iterate-references (p:ptr<long>,
-                                  f:ptr<((ptr<long>, ptr<VMState>) -> ref<False>)>,
-                                  vms:ptr<VMState>) -> ref<False> :
+protected lostanza defn iterate-references (p:ptr<long>,
+                                            f:ptr<((ptr<long>, ptr<VMState>) -> ref<False>)>,
+                                            vms:ptr<VMState>) -> ref<False> :
   ;Retrieve the object's tag.
   val tag = get-tag(p)
   ;Fast path using fast descriptor table.
@@ -2632,8 +2684,8 @@ public lostanza defn clear (start:ptr<?>, size:long) -> ptr<?> :
   return call-c clib/memset(start, 0, size)
 
 ;Call f on all root pointers.
-lostanza defn core-iterate-roots (f:ptr<((ptr<long>, ptr<VMState>) -> ref<False>)>,
-                                  vms:ptr<VMState>) -> ref<False> :
+protected lostanza defn core-iterate-roots (f:ptr<((ptr<long>, ptr<VMState>) -> ref<False>)>,
+                                            vms:ptr<VMState>) -> ref<False> :
   ;Scan globals
   val globals = vms.global-mem as ptr<long>
   val roots = vms.global-root-table
@@ -4203,6 +4255,7 @@ initialize-gc-notifiers()
 initialize-gc-statistics()
 initialize-liveness-handlers()
 initialize-symbol-table()
+initialize-dominator-tree()
 
 ;================================================================================
 ;========================== End of Boot Sequence ================================

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -3,6 +3,8 @@ defpackage core/heap-analysis :
   import collections
   import core/long-vector
 
+;;; UTILITIES
+
 defn scatter<?T> (src:Seqable<?T>, idx:Tuple<Int>) -> Tuple<T> :
   val dst = Array<T>(length(idx))
   for (x in src, i in 0 to false) do : dst[idx[i]] = x
@@ -17,6 +19,14 @@ defn gather<?T> (src:IndexedCollection<?T>, idx:Seqable<Int>) -> Seq<T> :
 lostanza defn clear (v:ptr<LSLongVector>) -> ref<False> :
   v.length = 0
   return false
+
+lostanza defn class-name (x:ref<Int>) -> ref<String> :
+  var res:ref<String>
+  if x.value == -1 :
+    res = String("root")
+  else :
+    res = String(class-name(x.value))
+  return res
 
 ;;; INTERFACE TO STANZA MEMORY SYSTEM
 
@@ -104,6 +114,7 @@ lostanza defn iterate-objects
     p = p + size
   return false 
 
+;; Look up offset into sorted list of object addresses using binary search
 lostanza defn addr-to-id (xs:ptr<LSLongVector>, x:long) -> long :
   var res:long = -1L
   labels :
@@ -117,6 +128,10 @@ lostanza defn addr-to-id (xs:ptr<LSLongVector>, x:long) -> long :
         else : goto loop(center + 1L, end)
   return res
 
+;;; LowFlatObject -- create flat and packed version of roots and objects
+;;;               -- stores tag, num-refs, refs for each object
+;;;               -- also has extra root root object with ref per root
+
 lostanza deftype LowFlatObjects :
   var sizes : ptr<LSLongVector> ; static sizes of objects
   var offs  : ptr<LSLongVector> ; offsets to inlined objects in heap
@@ -129,8 +144,8 @@ lostanza defn FlatObjects
     (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
   val lfo = call-c clib/stz_malloc(sizeof(LowFlatObjects)) as ptr<LowFlatObjects>
   lfo.sizes = sizes
-  lfo.offs = offs
-  lfo.heap = heap
+  lfo.offs  = offs
+  lfo.heap  = heap
   return new FlatObjects{ lfo }
 
 lostanza defmethod length (xs:ref<FlatObjects>) -> ref<Int> :
@@ -142,6 +157,7 @@ lostanza defn offset (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
 lostanza defmethod get (xs:ref<FlatObjects>, idx:ref<Int>) -> ref<Int> :
   return new Int{xs.value.heap.items[idx.value] as int}
 
+; for some reason can't name this method get like in stanza runtime
 defn get-all (xs:FlatObjects, indices:Range) -> Seq<Int> :
   seq({ xs[_] }, indices)
 
@@ -155,12 +171,13 @@ defn sizes (objs:FlatObjects) -> Seq<Int> :
   seq(size-of{objs, _}, 0 to length(objs))
 
 defn refs (objs:FlatObjects, id:Int) -> Seqable<Int> :
-  val off = offset(objs, id)
-  val len = objs[off + 1]
+  val off = offset(objs, id) ; base
+  val num-refs = objs[off + 1]
   val refs-off = off + 2 
-  get-all(objs, refs-off to (refs-off + len))
+  get-all(objs, refs-off to (refs-off + num-refs))
 
-lostanza defn do-dominator-tree () -> ref<FlatObjects> :
+;; Pack roots / heap into FlatObjects 
+lostanza defn FlatObjects () -> ref<FlatObjects> :
   call-c clib/printf("GC...\n")
   run-garbage-collector()
   val vms:ptr<core/VMState> = call-prim flush-vm()
@@ -178,22 +195,26 @@ lostanza defn do-dominator-tree () -> ref<FlatObjects> :
   val nursery = core/nursery-start(addr(vms.heap))
   call-c clib/printf("COLLECT NURSERY %lx OBJECT ADDRESSES AND SIZES...\n", nursery)
   iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-address-and-size))
-  call-c clib/printf("DONE %d OBJECTS...\n", addrs(dom).length)
+  call-c clib/printf("FOUND %d OBJECTS...\n", addrs(dom).length)
   ;; build heap data translated to object ids using addresses and binary search
   add(offs(dom), 0L)  ; first root object
   add(heap(dom), -1L) ; dummy root object tag
   add(heap(dom), roots(dom).length as long)
+  call-c clib/printf("CONVERTING ROOT ADDRESSES TO IDS...\n")
   for (var i:int = 0, i < roots(dom).length, i = i + 1) :
     add(heap(dom), addr-to-id(addrs(dom), roots(dom).items[i]) + 1) ; point to roots
+  call-c clib/printf("PACKING HEAP DATA...\n")
   iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-contents))
+  call-c clib/printf("PACKING NURSERY DATA...\n")
   iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-contents))
   clear(addrs(dom))
   clear(roots(dom))
-  call-c clib/printf("DONE... %d OFFS\n", offs(dom).length)
+  call-c clib/printf("DONE...\n")
   return FlatObjects(sizes(dom), offs(dom), heap(dom))
 
 ;;; FlatIdObjects
 
+;; Permutation wrapper of flat-objects
 defstruct FlatIdObjects :
   order   : Tuple<Int>
   reorder : Tuple<Int>
@@ -207,14 +228,6 @@ defn sizes (o:FlatIdObjects) -> Seq<Int> :
 defn length (ios:FlatIdObjects) -> Int :
   length(objs(ios))
 
-lostanza defn class-name (x:ref<Int>) -> ref<String> :
-  var res:ref<String>
-  if x.value == -1 :
-    res = String("root")
-  else :
-    res = String(class-name(x.value))
-  return res
-
 defn nexts (fobjs:FlatIdObjects) -> Tuple<List<Int>> :
   val objs = objs(fobjs)
   to-tuple $ for id in order(fobjs) seq :
@@ -226,25 +239,6 @@ defn prevs (nexts:Tuple<List<Int>>) -> Tuple<List<Int>> :
     for r in next do :
       prevs[r] = cons(id, prevs[r])
   to-tuple $ prevs
-
-defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
-  print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])
-
-defn print-id-object-guts (objs:FlatObjects) -> False :
-  for id in 0 to length(objs) do :
-    id-print-guts(id, tag-of(objs, id), refs(objs, id))
-    println("")
-
-defn id-print-stat (id:Int, tag:Int, tot-size:Int, size:Int) :
-  print("%_ = {%_ %_ %_}" % [id, class-name(tag), size, tot-size])
-
-defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
-  val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
-  for (id in ids, i in 0 to false) do :
-    val tot-size = tot-sizes[id]
-    if tot-size > 0 :
-      id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
-      println("")
 
 defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
   FlatIdObjects(to-tuple $ (0 to length(objs)), to-tuple $ (0 to length(objs)), objs)
@@ -336,16 +330,36 @@ defn print-xml
     P(depth, "</%_>" % [name])
 
 public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
-  val objs = do-dominator-tree()
+  val objs = FlatObjects()
   val id-objs0 = objects-to-id-objects(objs)
   val id-objs = depth-first(id-objs0)
   val nxts = nexts(id-objs)
   val doms = idom(length(id-objs), prevs(nxts))
   val sizes = calc-sizes(id-objs, doms)
-  print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
+  ; print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
   val s = FileOutputStream(filename)
   print-xml(s, id-objs, sizes, nxts, doms)
   close(s)
   id-objs
 
-; heap-dominator-tree("sizes.xml")
+heap-dominator-tree("sizes.xml")
+
+; defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
+;   print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])
+; 
+; defn print-id-object-guts (objs:FlatObjects) -> False :
+;   for id in 0 to length(objs) do :
+;     id-print-guts(id, tag-of(objs, id), refs(objs, id))
+;     println("")
+; 
+; defn id-print-stat (id:Int, tag:Int, tot-size:Int, size:Int) :
+;   print("%_ = {%_ %_ %_}" % [id, class-name(tag), size, tot-size])
+; 
+; defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
+;   val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
+;   for (id in ids, i in 0 to false) do :
+;     val tot-size = tot-sizes[id]
+;     if tot-size > 0 :
+;       id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
+;       println("")
+

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -1,0 +1,476 @@
+defpackage core/heap-analysis :
+  import core
+  import collections
+  import core/long-vector
+
+; TODO:
+; remove unique-id
+; flatten prevs/nexts ??? -- perhaps adaptive structure like a list
+
+defn scatter<?T> (src:Seqable<?T>, idx:Tuple<Int>) -> Tuple<T> :
+  val dst = Array<T>(length(idx))
+  for (x in src, i in 0 to false) do : dst[idx[i]] = x
+  to-tuple(dst)
+
+defn gather<?T> (src:Tuple<?T>, idx:Seqable<Int>) -> Seq<T> :
+  seq({ src[_] }, idx)
+
+defn gather<?T> (src:IndexedCollection<?T>, idx:Seqable<Int>) -> Seq<T> :
+  seq({ src[_] }, idx)
+
+lostanza defn clear (v:ptr<LSLongVector>) -> ref<False> :
+  v.length = 0
+  return false
+
+;;; INTERFACE TO STANZA MEMORY SYSTEM
+
+lostanza defn addrs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+  return dom.addrs as ptr<LSLongVector>
+
+lostanza defn heap (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+  return dom.heap as ptr<LSLongVector>
+
+lostanza defn sizes (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+  return dom.sizes as ptr<LSLongVector>
+
+lostanza defn roots (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+  return dom.roots as ptr<LSLongVector>
+
+lostanza defn offs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+  return dom.offs as ptr<LSLongVector>
+
+lostanza defn collect-object-address-and-size (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+  add(addrs(vms.dom), p as long)
+  ; call-c clib/printf("ADDR %lx\n", p)
+  add(sizes(vms.dom), size as long)
+  return false
+
+lostanza var unique-id:long = 1000L
+
+lostanza defn collect-object-contents (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+  add(offs(vms.dom), heap(vms.dom).length)
+  add(heap(vms.dom), tag as long)
+  add(heap(vms.dom), unique-id)
+  unique-id = unique-id + 1L
+  val idx = heap(vms.dom).length
+  add(heap(vms.dom), 0L) ; place holder
+  core/iterate-references(p, addr(do-collect-object-contents), vms)
+  heap(vms.dom).items[idx] = heap(vms.dom).length - idx - 1
+  return false
+
+lostanza defn do-collect-object-contents (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
+  ;Retrieve the value at the given heap pointer.
+  val v = [ref]
+  ;Is this a reference to a Stanza heap object?
+  val tagbits = v & 7L
+  if tagbits == 1L :
+    ;Remove the tag bits to retrieve the object pointer.
+    val p = (v - 1) as ptr<long>
+    add(heap(vms.dom), addr-to-id(addrs(vms.dom), p as long) + 1)
+  return false
+
+public lostanza defn register-all-roots (vms:ptr<core/VMState>) -> ref<False> :
+  core/core-iterate-roots(addr(register-root-reference), vms)
+  register-stack-roots(vms)
+  return false
+
+public lostanza defn register-stack-roots (vms:ptr<core/VMState>) -> ref<False> :
+  var stack:ptr<Stack> = vms.heap.stacks
+  while stack != null :
+    iterate-references-in-stack-frames(stack, addr(register-root-reference), vms)
+    stack = stack.tail
+  return false
+
+public lostanza defn register-root-reference (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
+  val v = [ref]
+  val tagbits = v & 7L ; heap object?
+  if tagbits == 1L :
+    val p = (v - 1) as ptr<long> ; remove tag bits to retrieve object pointer
+    add(roots(vms.dom), p as long)
+  return false
+
+lostanza defn iterate-objects
+    (pstart:ptr<long>, pend:ptr<long>, vms:ptr<core/VMState>, f:ptr<((ptr<long>, int, long, ptr<core/VMState>) -> ref<False>)>) -> ref<False> :
+  var p:ptr<long> = pstart
+  while p < pend :
+    val tag = [p] as int
+    val class = vms.class-table[tag].record
+    var size:long = 0L
+    if class.item-size == 0 :
+      size = object-size-on-heap(class.size)
+    else :
+      val class = class as ptr<core/ArrayRecord>
+      val array = p as ptr<ObjectLayout>
+      val len = array.slots[0]
+      val base-size = class.base-size
+      val item-size = class.item-size
+      val my-size = base-size + item-size * len
+      size = object-size-on-heap(my-size)
+    [f](p, tag, size, vms)
+    p = p + size
+  return false 
+
+lostanza defn addr-to-id (xs:ptr<LSLongVector>, x:long) -> long :
+  var res:long = -1L
+  labels :
+    begin: goto loop(0L, xs.length)
+    loop (start:long, end:long) :
+      if end > start :
+        val center = (start + end) >> 1
+        val xc = xs.items[center]
+        if x == xc : res = center
+        else if x < xc : goto loop(start, center)
+        else : goto loop(center + 1L, end)
+  return res
+
+lostanza deftype LowFlatObjects :
+  var sizes : ptr<LSLongVector> ; static sizes of objects
+  var offs  : ptr<LSLongVector> ; offsets to inlined objects in heap
+  var heap  : ptr<LSLongVector> ; | type | len | ids ... | ...
+
+lostanza deftype FlatObjects <: IndexedCollection&Lengthable :
+  value : ptr<LowFlatObjects>
+
+lostanza defn FlatObjects (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
+  val lfo = call-c clib/stz_malloc(sizeof(LowFlatObjects)) as ptr<LowFlatObjects>
+  lfo.sizes = sizes
+  lfo.offs = offs
+  lfo.heap = heap
+  return new FlatObjects{ lfo }
+
+lostanza defmethod length (xs:ref<FlatObjects>) -> ref<Int> :
+  return new Int{xs.value.offs.length}
+
+lostanza defn offset (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
+  return new Int{xs.value.offs.items[id.value] as int}
+
+lostanza defmethod get (xs:ref<FlatObjects>, idx:ref<Int>) -> ref<Int> :
+  return new Int{xs.value.heap.items[idx.value] as int}
+
+defn get-all (xs:FlatObjects, indices:Range) -> Seq<Int> :
+  seq({ xs[_] }, indices)
+
+defn tag-of (xs:FlatObjects, id:Int) -> Int :
+  xs[offset(xs, id)]
+
+defn unique-of (xs:FlatObjects, id:Int) -> Int :
+  xs[offset(xs, id) + 1]
+
+lostanza defn size-of (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
+  return new Int{ xs.value.sizes.items[id.value] as int }
+
+defn sizes (objs:FlatObjects) -> Seq<Int> :
+  seq(size-of{objs, _}, 0 to length(objs))
+
+defn refs (objs:FlatObjects, id:Int) -> Seqable<Int> :
+  val off = offset(objs, id)
+  val len = objs[off + 2]
+  val refs-off = off + 3
+  get-all(objs, refs-off to (refs-off + len))
+
+lostanza defn do-dominator-tree () -> ref<FlatObjects> :
+  call-c clib/printf("GC...\n")
+  run-garbage-collector()
+  val vms:ptr<core/VMState> = call-prim flush-vm()
+  val dom = vms.dom
+  clear(offs(dom))
+  clear(sizes(dom))
+  clear(heap(dom))
+  ;; get all roots
+  call-c clib/printf("REG ROOTS...\n")
+  register-all-roots(vms)
+  call-c clib/printf("FOUND %d ROOTS...\n", roots(dom).length)
+  ;; get sizes and addresses of objects on heap
+  add(sizes(dom), roots(dom).length as long) ; dummy root object
+  call-c clib/printf("COLLECT HEAP %lx OBJECT ADDRESSES AND SIZES...\n", vms.heap.start)
+  iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-address-and-size))
+  val nursery = core/nursery-start(addr(vms.heap))
+  call-c clib/printf("COLLECT NURSERY %lx OBJECT ADDRESSES AND SIZES...\n", nursery)
+  iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-address-and-size))
+  call-c clib/printf("DONE %d OBJECTS...\n", addrs(dom).length)
+  ;; build heap data translated to object ids using addresses and binary search
+  add(offs(dom), 0L)  ; first root object
+  add(heap(dom), -1L) ; dummy root object tag
+  add(heap(dom), unique-id)
+  unique-id = unique-id + 1L
+  add(heap(dom), roots(dom).length as long)
+  for (var i:int = 0, i < roots(dom).length, i = i + 1) :
+    add(heap(dom), addr-to-id(addrs(dom), roots(dom).items[i]) + 1) ; point to roots
+  iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-contents))
+  iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-contents))
+  clear(addrs(dom))
+  clear(roots(dom))
+  call-c clib/printf("DONE... %d OFFS\n", offs(dom).length)
+  return FlatObjects(sizes(dom), offs(dom), heap(dom))
+
+;;; FlatIdObjects
+
+defstruct FlatIdObjects :
+  order   : Tuple<Int>
+  reorder : Tuple<Int>
+  objs    : FlatObjects
+with:
+  printer => true
+
+defn sizes (o:FlatIdObjects) -> Seq<Int> :
+  gather(to-tuple(sizes(objs(o))), order(o))
+
+defn length (ios:FlatIdObjects) -> Int :
+  length(objs(ios))
+
+lostanza defn class-name (x:ref<Int>) -> ref<String> :
+  var res:ref<String>
+  if x.value == -1 :
+    res = String("root")
+  else :
+    res = String(class-name(x.value))
+  return res
+
+defn nexts (fobjs:FlatIdObjects) -> Tuple<List<Int>> :
+  val objs = objs(fobjs)
+  to-tuple $ for id in order(fobjs) seq :
+    to-list $ seq({ reorder(fobjs)[_] }, refs(objs, id))
+
+defn prevs (nexts:Tuple<List<Int>>) -> Tuple<List<Int>> :
+  val prevs = Array<List<Int>>(length(nexts), List())
+  for (next in nexts, id in 0 to false) do :
+    for r in next do :
+      prevs[r] = cons(id, prevs[r])
+  to-tuple $ prevs
+
+defn id-print-guts (idx:Int, id:Int, unique:Int, tag:Int, refs:Seqable<Int>) :
+  print("%_: %_ = {%_ %_ %_}" % [idx, id, class-name(tag), unique, to-tuple $ refs])
+
+defn print-id-object-guts (objs:FlatObjects) -> False :
+  for id in 0 to length(objs) do :
+    id-print-guts(id, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+    println("")
+
+defn id-print-stat (idx:Int, id:Int, unique:Int, tag:Int, tot-size:Int, size:Int) :
+  print("%_: %_ = {%_ %_ %_ %_}" % [idx, id, class-name(tag), unique, size, tot-size])
+
+defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
+  val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
+  for (id in ids, i in 0 to false) do :
+    val tot-size = tot-sizes[id]
+    if tot-size > 0 :
+      id-print-stat(i, id, unique-of(objs, id), tag-of(objs, id), tot-size, size-of(objs, id))
+      println("")
+
+defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
+  ; print-id-object-guts(objs)
+  FlatIdObjects(to-tuple $ (0 to length(objs)), to-tuple $ (0 to length(objs)), objs)
+
+;;; DOMINATORS
+
+;; find depth first order of objects
+defn depth-first (ios:FlatIdObjects) -> FlatIdObjects :
+  val nexts = nexts(ios)
+  val visited? = Array<True|False>(length(ios), false)
+  val order0 = Vector<Int>()
+  let loop (idx:Int = 0) :
+    if not visited?[idx] :
+      visited?[idx] = true
+      for nidx in nexts[idx] do : loop(nidx)
+      add(order0, idx)
+  val missing = filter({ not visited?[_] }, 0 to length(visited?))
+  val order = to-tuple $ cat(missing, order0)
+  ; println("DFS %_ %_" % [length(order), order])
+  FlatIdObjects(to-tuple $ order, scatter(0 to length(order), to-tuple(order)), objs(ios))
+
+; fast dominators algorithm assuming depth-first order
+defn idom (num:Int, prevs:Tuple<List<Int>>) -> Tuple<Int> :
+  ; println("IDOM NUM %_ PREVS %_" % [num, prevs])
+  val doms = Array<Int>(num, -1)
+  val start-id = num - 1
+  doms[start-id] = start-id
+  defn intersect (b1:Int, b2:Int) -> Int :
+    let loop (finger1:Int = b1, finger2:Int = b2) :
+      if finger1 != finger2 :
+        val finger1 = let iter (finger1:Int = finger1) :
+          if finger1 < finger2 : iter(doms[finger1])
+          else : finger1
+        val finger2 = let iter (finger2:Int = finger2) :
+          if finger2 < finger1 : iter(doms[finger2])
+          else : finger2
+        loop(finger1, finger2)
+      else :
+        finger1
+  let loop () :
+    let iter (b : Int = start-id - 1, changed? : True|False = false) :
+      if b >= 0 :
+        val new-idom = let find (idom:Int = -1, ps:List<Int> = prevs[b]) :
+          if empty?(ps) :
+            idom
+          else :
+            val p = head(ps)
+            val nxt-idom =
+              if doms[p] != -1 :
+                if idom == -1 : p
+                else : intersect(p, idom)
+              else : idom
+            find(nxt-idom, tail(ps))
+        val changed? = doms[b] != new-idom
+        doms[b] = new-idom
+        iter(b - 1, changed?)          
+      else :
+        loop() when changed?
+  to-tuple $ doms
+
+defn calc-sizes (ios:FlatIdObjects, doms:Tuple<Int>) -> Array<Int> :
+  val tot-sizes = to-array<Int> $ sizes(ios)
+  ; println("%_: %_" % [0, tot-sizes])
+  val len = length(ios)
+  for i in 0 to (len - 1) do :
+    if doms[i] >= 0 :
+      tot-sizes[doms[i]] = tot-sizes[doms[i]] + tot-sizes[i]
+      ; println("%_: %_" % [i + 1, tot-sizes])
+  tot-sizes
+
+defn print-xml (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>, nexts:Tuple<List<Int>>, doms:Tuple<Int>, threshold:Int = 0) :
+  val objs = objs(id-objs)
+  defn children (doms:Tuple<Int>) -> Tuple<Tuple<Int>> :
+    val children = to-tuple $ repeatedly({ Vector<Int>() }, length(nexts))
+    for (dom in doms, id in 0 to false) do :
+      add(children[dom], id) when (dom >= 0 and dom != id)
+    map(to-tuple, children)
+  defn stringify (s:String) -> String :
+    replace(s, "&", "A")
+  defn indent (n:Int) :
+    for i in 0 to n do : print(s, " ")
+  val kiddies = children(doms)
+  let walk (idx:Int = length(doms) - 1, depth:Int = 0) :
+    val id = order(id-objs)[idx]
+    val name = stringify(class-name(tag-of(objs, id)))
+    indent(depth * 2) println(s, "<%_ RETAINED=\"%_\" STATIC=\"%_\">" % [name, sizes[idx], size-of(objs, id)])
+    val childs = reverse $ to-list $ qsort({ sizes[_] }, filter({ sizes[_] > threshold }, kiddies[idx]))
+    for child in childs do :
+      walk(child, depth + 1)
+    indent(depth * 2) println(s, "</%_>" % [name])
+
+public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
+  val objs = do-dominator-tree()
+  ; val objs = tst-dominator-tree()
+  ; dump-heap(objs)
+  val id-objs0 = objects-to-id-objects(objs)
+  ; val nxts0 = nexts(id-objs0)
+  ; val prvs0 = prevs(nxts0)
+  ; for (id in order(id-objs0), i in 0 to false) do :
+  ;   id-print-guts(i, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+  ;   print("  NEXTS %_ PREVS %_" % [nxts0[i], prvs0[i]])
+  ;   println("")
+  val id-objs = depth-first(id-objs0)
+  ; val nxts = nexts(id-objs)
+  ; val prvs = prevs(nxts)
+  ; for (id in order(id-objs), i in 0 to false) do :
+  ;   id-print-guts(i, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+  ;   print("  NEXTS %_ PREVS %_" % [nxts[i], prvs[i]])
+  ;   println("")
+  val nxts = nexts(id-objs)
+  val doms = idom(length(id-objs), prevs(nxts))
+  ; println("IDOM DONE %_" % [doms])
+  val sizes = calc-sizes(id-objs, doms)
+  ; println("SIZES %_" % [sizes])
+  print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
+  val s = FileOutputStream(filename)
+  print-xml(s, id-objs, sizes, nxts, doms)
+  close(s)
+  id-objs
+
+; defstruct Tup :
+;   value : Tuple
+; 
+; val tup3 = Tup([ 0 1 2 3 4 5 6 7 8 9 ])
+; val tup2 = Tup([ tup3 tup3 ])
+; val tup1 = Tup([ tup2 tup2 ])
+; val tup0 = Tup([ tup1 tup1 ])
+
+defstruct BinTree :
+  left : BinTree|Int
+  right : BinTree|Int
+
+defn bin-tree (n:Int) -> BinTree :
+  if n <= 0 :
+    BinTree(0, 1)
+  else :
+    BinTree(bin-tree(n - 1), bin-tree(n - 1))
+
+val tup = bin-tree(6)
+
+heap-dominator-tree("sizes.xml")
+
+; val tst-2 = [ 1 ]
+; val tst-1 = [ tst-2 ]
+; val tst-0 = [ tst-1, tst-2 ]
+; 
+; lostanza defn object-type-id (x:ref<?>) -> int :
+;   val ref = x as long
+;   val p = (ref - 1L) as ptr<long>
+;   return [p] as int
+; 
+; lostanza defn tst-dominator-tree () -> ref<FlatObjects> :
+;   val vms:ptr<core/VMState> = call-prim flush-vm()
+;   val dom = vms.dom
+;   clear(offs(dom))
+;   clear(sizes(dom))
+;   clear(heap(dom))
+;   ;0
+;   add(offs(dom), 0L)
+;   add(heap(dom), -1L)
+;   add(heap(dom), unique-id)
+;   unique-id = unique-id + 1L
+;   add(heap(dom), 1L)
+;   add(heap(dom), 2L)
+;   add(sizes(dom), 2L * 8L)
+;   ;1
+;   add(offs(dom), heap(dom).length)
+;   add(heap(dom), object-type-id(tst-1))
+;   add(heap(dom), unique-id)
+;   unique-id = unique-id + 1L
+;   add(heap(dom), 1L)
+;   add(heap(dom), 3L)
+;   add(sizes(dom), 8L + 1L * 8L)
+;   ;2
+;   add(offs(dom), heap(dom).length)
+;   add(heap(dom), object-type-id(tst-0))
+;   add(heap(dom), unique-id)
+;   unique-id = unique-id + 1L
+;   add(heap(dom), 2L)
+;   add(heap(dom), 1L)
+;   add(heap(dom), 3L)
+;   add(sizes(dom), 8L + 2L * 8L)
+;   ;3
+;   add(offs(dom), heap(dom).length)
+;   add(heap(dom), object-type-id(tst-1))
+;   add(heap(dom), unique-id)
+;   unique-id = unique-id + 1L
+;   add(heap(dom), 0L)
+;   add(sizes(dom), 8L)
+;   return FlatObjects(sizes(dom), offs(dom), heap(dom))
+
+lostanza defn dump-heap (objs:ref<FlatObjects>) -> ref<False> :
+  call-c clib/printf("OFFS:\n")
+  for (var i:int = 0, i < objs.value.offs.length, i = i + 1) :
+    call-c clib/printf("%d : %ld\n", i, objs.value.offs.items[i])
+  call-c clib/printf("HEAP:\n")
+  for (var i:int = 0, i < objs.value.heap.length, i = i + 1) :
+    call-c clib/printf("%d : %ld\n", i, objs.value.heap.items[i])
+  return false
+
+defstruct IntArrayPow2 :
+  sizes : IntArray
+  offs  : IntArray
+  items : IntArray
+
+defn accum (xs:Seqable<Int>, init:Int) -> Seq<Int> :
+  var accum:Int = init
+  for x in xs seq : (val r = accum, accum = accum + x, r)
+
+defn IntArrayPow2 (sizes:IntArray) -> IntArrayPow2 :
+  val len  = length(sizes)
+  val offs = to-intarray $ accum(sizes, 0)
+  val items = IntArray(offs[len - 1] + sizes[len - 1])
+  IntArrayPow2(sizes, offs, items)
+
+defn get (vv:IntArrayPow2, idx:Int) -> Collection<Int> :
+  items(vv)[offs(vv)[idx] to (offs(vv)[idx] + sizes(vv)[idx])]

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -3,10 +3,6 @@ defpackage core/heap-analysis :
   import collections
   import core/long-vector
 
-; TODO:
-; remove unique-id
-; flatten prevs/nexts ??? -- perhaps adaptive structure like a list
-
 defn scatter<?T> (src:Seqable<?T>, idx:Tuple<Int>) -> Tuple<T> :
   val dst = Array<T>(length(idx))
   for (x in src, i in 0 to false) do : dst[idx[i]] = x
@@ -41,17 +37,12 @@ lostanza defn offs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
 
 lostanza defn collect-object-address-and-size (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
   add(addrs(vms.dom), p as long)
-  ; call-c clib/printf("ADDR %lx\n", p)
   add(sizes(vms.dom), size as long)
   return false
-
-lostanza var unique-id:long = 1000L
 
 lostanza defn collect-object-contents (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
   add(offs(vms.dom), heap(vms.dom).length)
   add(heap(vms.dom), tag as long)
-  add(heap(vms.dom), unique-id)
-  unique-id = unique-id + 1L
   val idx = heap(vms.dom).length
   add(heap(vms.dom), 0L) ; place holder
   core/iterate-references(p, addr(do-collect-object-contents), vms)
@@ -153,9 +144,6 @@ defn get-all (xs:FlatObjects, indices:Range) -> Seq<Int> :
 defn tag-of (xs:FlatObjects, id:Int) -> Int :
   xs[offset(xs, id)]
 
-defn unique-of (xs:FlatObjects, id:Int) -> Int :
-  xs[offset(xs, id) + 1]
-
 lostanza defn size-of (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
   return new Int{ xs.value.sizes.items[id.value] as int }
 
@@ -164,8 +152,8 @@ defn sizes (objs:FlatObjects) -> Seq<Int> :
 
 defn refs (objs:FlatObjects, id:Int) -> Seqable<Int> :
   val off = offset(objs, id)
-  val len = objs[off + 2]
-  val refs-off = off + 3
+  val len = objs[off + 1]
+  val refs-off = off + 2 
   get-all(objs, refs-off to (refs-off + len))
 
 lostanza defn do-dominator-tree () -> ref<FlatObjects> :
@@ -177,7 +165,6 @@ lostanza defn do-dominator-tree () -> ref<FlatObjects> :
   clear(sizes(dom))
   clear(heap(dom))
   ;; get all roots
-  call-c clib/printf("REG ROOTS...\n")
   register-all-roots(vms)
   call-c clib/printf("FOUND %d ROOTS...\n", roots(dom).length)
   ;; get sizes and addresses of objects on heap
@@ -191,8 +178,6 @@ lostanza defn do-dominator-tree () -> ref<FlatObjects> :
   ;; build heap data translated to object ids using addresses and binary search
   add(offs(dom), 0L)  ; first root object
   add(heap(dom), -1L) ; dummy root object tag
-  add(heap(dom), unique-id)
-  unique-id = unique-id + 1L
   add(heap(dom), roots(dom).length as long)
   for (var i:int = 0, i < roots(dom).length, i = i + 1) :
     add(heap(dom), addr-to-id(addrs(dom), roots(dom).items[i]) + 1) ; point to roots
@@ -238,23 +223,23 @@ defn prevs (nexts:Tuple<List<Int>>) -> Tuple<List<Int>> :
       prevs[r] = cons(id, prevs[r])
   to-tuple $ prevs
 
-defn id-print-guts (idx:Int, id:Int, unique:Int, tag:Int, refs:Seqable<Int>) :
-  print("%_: %_ = {%_ %_ %_}" % [idx, id, class-name(tag), unique, to-tuple $ refs])
+defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
+  print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])
 
 defn print-id-object-guts (objs:FlatObjects) -> False :
   for id in 0 to length(objs) do :
-    id-print-guts(id, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+    id-print-guts(id, tag-of(objs, id), refs(objs, id))
     println("")
 
-defn id-print-stat (idx:Int, id:Int, unique:Int, tag:Int, tot-size:Int, size:Int) :
-  print("%_: %_ = {%_ %_ %_ %_}" % [idx, id, class-name(tag), unique, size, tot-size])
+defn id-print-stat (id:Int, tag:Int, tot-size:Int, size:Int) :
+  print("%_ = {%_ %_ %_}" % [id, class-name(tag), size, tot-size])
 
 defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
   val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
   for (id in ids, i in 0 to false) do :
     val tot-size = tot-sizes[id]
     if tot-size > 0 :
-      id-print-stat(i, id, unique-of(objs, id), tag-of(objs, id), tot-size, size-of(objs, id))
+      id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
       println("")
 
 defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
@@ -356,14 +341,14 @@ public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
   ; val nxts0 = nexts(id-objs0)
   ; val prvs0 = prevs(nxts0)
   ; for (id in order(id-objs0), i in 0 to false) do :
-  ;   id-print-guts(i, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+  ;   id-print-guts(i, id, tag-of(objs, id), refs(objs, id))
   ;   print("  NEXTS %_ PREVS %_" % [nxts0[i], prvs0[i]])
   ;   println("")
   val id-objs = depth-first(id-objs0)
   ; val nxts = nexts(id-objs)
   ; val prvs = prevs(nxts)
   ; for (id in order(id-objs), i in 0 to false) do :
-  ;   id-print-guts(i, id, unique-of(objs, id), tag-of(objs, id), refs(objs, id))
+  ;   id-print-guts(i, id, tag-of(objs, id), refs(objs, id))
   ;   print("  NEXTS %_ PREVS %_" % [nxts[i], prvs[i]])
   ;   println("")
   val nxts = nexts(id-objs)
@@ -417,24 +402,18 @@ heap-dominator-tree("sizes.xml")
 ;   ;0
 ;   add(offs(dom), 0L)
 ;   add(heap(dom), -1L)
-;   add(heap(dom), unique-id)
-;   unique-id = unique-id + 1L
 ;   add(heap(dom), 1L)
 ;   add(heap(dom), 2L)
 ;   add(sizes(dom), 2L * 8L)
 ;   ;1
 ;   add(offs(dom), heap(dom).length)
 ;   add(heap(dom), object-type-id(tst-1))
-;   add(heap(dom), unique-id)
-;   unique-id = unique-id + 1L
 ;   add(heap(dom), 1L)
 ;   add(heap(dom), 3L)
 ;   add(sizes(dom), 8L + 1L * 8L)
 ;   ;2
 ;   add(offs(dom), heap(dom).length)
 ;   add(heap(dom), object-type-id(tst-0))
-;   add(heap(dom), unique-id)
-;   unique-id = unique-id + 1L
 ;   add(heap(dom), 2L)
 ;   add(heap(dom), 1L)
 ;   add(heap(dom), 3L)
@@ -442,8 +421,6 @@ heap-dominator-tree("sizes.xml")
 ;   ;3
 ;   add(offs(dom), heap(dom).length)
 ;   add(heap(dom), object-type-id(tst-1))
-;   add(heap(dom), unique-id)
-;   unique-id = unique-id + 1L
 ;   add(heap(dom), 0L)
 ;   add(sizes(dom), 8L)
 ;   return FlatObjects(sizes(dom), offs(dom), heap(dom))

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -35,12 +35,14 @@ lostanza defn roots (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
 lostanza defn offs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
   return dom.offs as ptr<LSLongVector>
 
-lostanza defn collect-object-address-and-size (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+lostanza defn collect-object-address-and-size
+    (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
   add(addrs(vms.dom), p as long)
   add(sizes(vms.dom), size as long)
   return false
 
-lostanza defn collect-object-contents (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+lostanza defn collect-object-contents
+    (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
   add(offs(vms.dom), heap(vms.dom).length)
   add(heap(vms.dom), tag as long)
   val idx = heap(vms.dom).length
@@ -81,7 +83,8 @@ public lostanza defn register-root-reference (ref:ptr<long>, vms:ptr<core/VMStat
   return false
 
 lostanza defn iterate-objects
-    (pstart:ptr<long>, pend:ptr<long>, vms:ptr<core/VMState>, f:ptr<((ptr<long>, int, long, ptr<core/VMState>) -> ref<False>)>) -> ref<False> :
+    (pstart:ptr<long>, pend:ptr<long>, vms:ptr<core/VMState>,
+     f:ptr<((ptr<long>, int, long, ptr<core/VMState>) -> ref<False>)>) -> ref<False> :
   var p:ptr<long> = pstart
   while p < pend :
     val tag = [p] as int
@@ -122,7 +125,8 @@ lostanza deftype LowFlatObjects :
 lostanza deftype FlatObjects <: IndexedCollection&Lengthable :
   value : ptr<LowFlatObjects>
 
-lostanza defn FlatObjects (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
+lostanza defn FlatObjects
+    (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
   val lfo = call-c clib/stz_malloc(sizeof(LowFlatObjects)) as ptr<LowFlatObjects>
   lfo.sizes = sizes
   lfo.offs = offs
@@ -243,7 +247,6 @@ defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
       println("")
 
 defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
-  ; print-id-object-guts(objs)
   FlatIdObjects(to-tuple $ (0 to length(objs)), to-tuple $ (0 to length(objs)), objs)
 
 ;;; DOMINATORS
@@ -260,12 +263,10 @@ defn depth-first (ios:FlatIdObjects) -> FlatIdObjects :
       add(order0, idx)
   val missing = filter({ not visited?[_] }, 0 to length(visited?))
   val order = to-tuple $ cat(missing, order0)
-  ; println("DFS %_ %_" % [length(order), order])
   FlatIdObjects(to-tuple $ order, scatter(0 to length(order), to-tuple(order)), objs(ios))
 
 ; fast dominators algorithm assuming depth-first order
 defn idom (num:Int, prevs:Tuple<List<Int>>) -> Tuple<Int> :
-  ; println("IDOM NUM %_ PREVS %_" % [num, prevs])
   val doms = Array<Int>(num, -1)
   val start-id = num - 1
   doms[start-id] = start-id
@@ -304,15 +305,15 @@ defn idom (num:Int, prevs:Tuple<List<Int>>) -> Tuple<Int> :
 
 defn calc-sizes (ios:FlatIdObjects, doms:Tuple<Int>) -> Array<Int> :
   val tot-sizes = to-array<Int> $ sizes(ios)
-  ; println("%_: %_" % [0, tot-sizes])
   val len = length(ios)
   for i in 0 to (len - 1) do :
     if doms[i] >= 0 :
       tot-sizes[doms[i]] = tot-sizes[doms[i]] + tot-sizes[i]
-      ; println("%_: %_" % [i + 1, tot-sizes])
   tot-sizes
 
-defn print-xml (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>, nexts:Tuple<List<Int>>, doms:Tuple<Int>, threshold:Int = 0) :
+defn print-xml
+    (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>,
+     nexts:Tuple<List<Int>>, doms:Tuple<Int>, threshold:Int = 0) :
   val objs = objs(id-objs)
   defn children (doms:Tuple<Int>) -> Tuple<Tuple<Int>> :
     val children = to-tuple $ repeatedly({ Vector<Int>() }, length(nexts))
@@ -321,133 +322,30 @@ defn print-xml (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>, nex
     map(to-tuple, children)
   defn stringify (s:String) -> String :
     replace(s, "&", "A")
-  defn indent (n:Int) :
-    for i in 0 to n do : print(s, " ")
+  defn P (n:Int, str:Printable) :
+    for i in 0 to (n * 2) do : print(s, " ")
+    println(s, str)
   val kiddies = children(doms)
   let walk (idx:Int = length(doms) - 1, depth:Int = 0) :
     val id = order(id-objs)[idx]
     val name = stringify(class-name(tag-of(objs, id)))
-    indent(depth * 2) println(s, "<%_ RETAINED=\"%_\" STATIC=\"%_\">" % [name, sizes[idx], size-of(objs, id)])
+    P(depth, "<%_ RETAINED=\"%_\" STATIC=\"%_\">" % [name, sizes[idx], size-of(objs, id)])
     val childs = reverse $ to-list $ qsort({ sizes[_] }, filter({ sizes[_] > threshold }, kiddies[idx]))
     for child in childs do :
       walk(child, depth + 1)
-    indent(depth * 2) println(s, "</%_>" % [name])
+    P(depth, "</%_>" % [name])
 
 public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
   val objs = do-dominator-tree()
-  ; val objs = tst-dominator-tree()
-  ; dump-heap(objs)
   val id-objs0 = objects-to-id-objects(objs)
-  ; val nxts0 = nexts(id-objs0)
-  ; val prvs0 = prevs(nxts0)
-  ; for (id in order(id-objs0), i in 0 to false) do :
-  ;   id-print-guts(i, id, tag-of(objs, id), refs(objs, id))
-  ;   print("  NEXTS %_ PREVS %_" % [nxts0[i], prvs0[i]])
-  ;   println("")
   val id-objs = depth-first(id-objs0)
-  ; val nxts = nexts(id-objs)
-  ; val prvs = prevs(nxts)
-  ; for (id in order(id-objs), i in 0 to false) do :
-  ;   id-print-guts(i, id, tag-of(objs, id), refs(objs, id))
-  ;   print("  NEXTS %_ PREVS %_" % [nxts[i], prvs[i]])
-  ;   println("")
   val nxts = nexts(id-objs)
   val doms = idom(length(id-objs), prevs(nxts))
-  ; println("IDOM DONE %_" % [doms])
   val sizes = calc-sizes(id-objs, doms)
-  ; println("SIZES %_" % [sizes])
   print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
   val s = FileOutputStream(filename)
   print-xml(s, id-objs, sizes, nxts, doms)
   close(s)
   id-objs
 
-; defstruct Tup :
-;   value : Tuple
-; 
-; val tup3 = Tup([ 0 1 2 3 4 5 6 7 8 9 ])
-; val tup2 = Tup([ tup3 tup3 ])
-; val tup1 = Tup([ tup2 tup2 ])
-; val tup0 = Tup([ tup1 tup1 ])
-
-defstruct BinTree :
-  left : BinTree|Int
-  right : BinTree|Int
-
-defn bin-tree (n:Int) -> BinTree :
-  if n <= 0 :
-    BinTree(0, 1)
-  else :
-    BinTree(bin-tree(n - 1), bin-tree(n - 1))
-
-val tup = bin-tree(6)
-
-heap-dominator-tree("sizes.xml")
-
-; val tst-2 = [ 1 ]
-; val tst-1 = [ tst-2 ]
-; val tst-0 = [ tst-1, tst-2 ]
-; 
-; lostanza defn object-type-id (x:ref<?>) -> int :
-;   val ref = x as long
-;   val p = (ref - 1L) as ptr<long>
-;   return [p] as int
-; 
-; lostanza defn tst-dominator-tree () -> ref<FlatObjects> :
-;   val vms:ptr<core/VMState> = call-prim flush-vm()
-;   val dom = vms.dom
-;   clear(offs(dom))
-;   clear(sizes(dom))
-;   clear(heap(dom))
-;   ;0
-;   add(offs(dom), 0L)
-;   add(heap(dom), -1L)
-;   add(heap(dom), 1L)
-;   add(heap(dom), 2L)
-;   add(sizes(dom), 2L * 8L)
-;   ;1
-;   add(offs(dom), heap(dom).length)
-;   add(heap(dom), object-type-id(tst-1))
-;   add(heap(dom), 1L)
-;   add(heap(dom), 3L)
-;   add(sizes(dom), 8L + 1L * 8L)
-;   ;2
-;   add(offs(dom), heap(dom).length)
-;   add(heap(dom), object-type-id(tst-0))
-;   add(heap(dom), 2L)
-;   add(heap(dom), 1L)
-;   add(heap(dom), 3L)
-;   add(sizes(dom), 8L + 2L * 8L)
-;   ;3
-;   add(offs(dom), heap(dom).length)
-;   add(heap(dom), object-type-id(tst-1))
-;   add(heap(dom), 0L)
-;   add(sizes(dom), 8L)
-;   return FlatObjects(sizes(dom), offs(dom), heap(dom))
-
-lostanza defn dump-heap (objs:ref<FlatObjects>) -> ref<False> :
-  call-c clib/printf("OFFS:\n")
-  for (var i:int = 0, i < objs.value.offs.length, i = i + 1) :
-    call-c clib/printf("%d : %ld\n", i, objs.value.offs.items[i])
-  call-c clib/printf("HEAP:\n")
-  for (var i:int = 0, i < objs.value.heap.length, i = i + 1) :
-    call-c clib/printf("%d : %ld\n", i, objs.value.heap.items[i])
-  return false
-
-defstruct IntArrayPow2 :
-  sizes : IntArray
-  offs  : IntArray
-  items : IntArray
-
-defn accum (xs:Seqable<Int>, init:Int) -> Seq<Int> :
-  var accum:Int = init
-  for x in xs seq : (val r = accum, accum = accum + x, r)
-
-defn IntArrayPow2 (sizes:IntArray) -> IntArrayPow2 :
-  val len  = length(sizes)
-  val offs = to-intarray $ accum(sizes, 0)
-  val items = IntArray(offs[len - 1] + sizes[len - 1])
-  IntArrayPow2(sizes, offs, items)
-
-defn get (vv:IntArrayPow2, idx:Int) -> Collection<Int> :
-  items(vv)[offs(vv)[idx] to (offs(vv)[idx] + sizes(vv)[idx])]
+; heap-dominator-tree("sizes.xml")

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -30,6 +30,10 @@ lostanza defn class-name (x:ref<Int>) -> ref<String> :
 
 #if-defined(BOOTSTRAP) :
 
+  public defn heap-dominator-tree (filename:String) : false
+
+#else :
+
   ;;; INTERFACE TO STANZA MEMORY SYSTEM
 
   lostanza defn addrs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
@@ -363,8 +367,4 @@ lostanza defn class-name (x:ref<Int>) -> ref<String> :
   ;     if tot-size > 0 :
   ;       id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
   ;       println("")
-
-#else :
-
-  public defn heap-dominator-tree (filename:String) : false
 

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -28,338 +28,343 @@ lostanza defn class-name (x:ref<Int>) -> ref<String> :
     res = String(class-name(x.value))
   return res
 
-;;; INTERFACE TO STANZA MEMORY SYSTEM
+#if-defined(BOOTSTRAP) :
 
-lostanza defn addrs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
-  return dom.addrs as ptr<LSLongVector>
+  ;;; INTERFACE TO STANZA MEMORY SYSTEM
 
-lostanza defn heap (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
-  return dom.heap as ptr<LSLongVector>
+  lostanza defn addrs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+    return dom.addrs as ptr<LSLongVector>
 
-lostanza defn sizes (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
-  return dom.sizes as ptr<LSLongVector>
+  lostanza defn heap (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+    return dom.heap as ptr<LSLongVector>
 
-lostanza defn roots (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
-  return dom.roots as ptr<LSLongVector>
+  lostanza defn sizes (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+    return dom.sizes as ptr<LSLongVector>
 
-lostanza defn offs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
-  return dom.offs as ptr<LSLongVector>
+  lostanza defn roots (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+    return dom.roots as ptr<LSLongVector>
 
-lostanza defn collect-object-address-and-size
-    (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
-  add(addrs(vms.dom), p as long)
-  add(sizes(vms.dom), size as long)
-  return false
+  lostanza defn offs (dom:ptr<core/HeapDominator>) -> ptr<LSLongVector> :
+    return dom.offs as ptr<LSLongVector>
 
-lostanza defn collect-object-contents
-    (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
-  add(offs(vms.dom), heap(vms.dom).length)
-  add(heap(vms.dom), tag as long)
-  val idx = heap(vms.dom).length
-  add(heap(vms.dom), 0L) ; place holder
-  core/iterate-references(p, addr(do-collect-object-contents), vms)
-  heap(vms.dom).items[idx] = heap(vms.dom).length - idx - 1
-  return false
+  lostanza defn collect-object-address-and-size
+      (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+    add(addrs(vms.dom), p as long)
+    add(sizes(vms.dom), size as long)
+    return false
 
-lostanza defn do-collect-object-contents (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
-  ;Retrieve the value at the given heap pointer.
-  val v = [ref]
-  ;Is this a reference to a Stanza heap object?
-  val tagbits = v & 7L
-  if tagbits == 1L :
-    ;Remove the tag bits to retrieve the object pointer.
-    val p = (v - 1) as ptr<long>
-    add(heap(vms.dom), addr-to-id(addrs(vms.dom), p as long) + 1)
-  return false
+  lostanza defn collect-object-contents
+      (p:ptr<long>, tag:int, size:long, vms:ptr<core/VMState>) -> ref<False> :
+    add(offs(vms.dom), heap(vms.dom).length)
+    add(heap(vms.dom), tag as long)
+    val idx = heap(vms.dom).length
+    add(heap(vms.dom), 0L) ; place holder
+    core/iterate-references(p, addr(do-collect-object-contents), vms)
+    heap(vms.dom).items[idx] = heap(vms.dom).length - idx - 1
+    return false
 
-public lostanza defn register-all-roots (vms:ptr<core/VMState>) -> ref<False> :
-  core/core-iterate-roots(addr(register-root-reference), vms)
-  register-stack-roots(vms)
-  return false
+  lostanza defn do-collect-object-contents (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
+    ;Retrieve the value at the given heap pointer.
+    val v = [ref]
+    ;Is this a reference to a Stanza heap object?
+    val tagbits = v & 7L
+    if tagbits == 1L :
+      ;Remove the tag bits to retrieve the object pointer.
+      val p = (v - 1) as ptr<long>
+      add(heap(vms.dom), addr-to-id(addrs(vms.dom), p as long) + 1)
+    return false
 
-public lostanza defn register-stack-roots (vms:ptr<core/VMState>) -> ref<False> :
-  var stack:ptr<Stack> = vms.heap.stacks
-  while stack != null :
-    iterate-references-in-stack-frames(stack, addr(register-root-reference), vms)
-    stack = stack.tail
-  return false
+  public lostanza defn register-all-roots (vms:ptr<core/VMState>) -> ref<False> :
+    core/core-iterate-roots(addr(register-root-reference), vms)
+    register-stack-roots(vms)
+    return false
 
-public lostanza defn register-root-reference (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
-  val v = [ref]
-  val tagbits = v & 7L ; heap object?
-  if tagbits == 1L :
-    val p = (v - 1) as ptr<long> ; remove tag bits to retrieve object pointer
-    add(roots(vms.dom), p as long)
-  return false
+  public lostanza defn register-stack-roots (vms:ptr<core/VMState>) -> ref<False> :
+    var stack:ptr<Stack> = vms.heap.stacks
+    while stack != null :
+      iterate-references-in-stack-frames(stack, addr(register-root-reference), vms)
+      stack = stack.tail
+    return false
 
-lostanza defn iterate-objects
-    (pstart:ptr<long>, pend:ptr<long>, vms:ptr<core/VMState>,
-     f:ptr<((ptr<long>, int, long, ptr<core/VMState>) -> ref<False>)>) -> ref<False> :
-  var p:ptr<long> = pstart
-  while p < pend :
-    val tag = [p] as int
-    val class = vms.class-table[tag].record
-    var size:long = 0L
-    if class.item-size == 0 :
-      size = object-size-on-heap(class.size)
-    else :
-      val class = class as ptr<core/ArrayRecord>
-      val array = p as ptr<ObjectLayout>
-      val len = array.slots[0]
-      val base-size = class.base-size
-      val item-size = class.item-size
-      val my-size = base-size + item-size * len
-      size = object-size-on-heap(my-size)
-    [f](p, tag, size, vms)
-    p = p + size
-  return false 
+  public lostanza defn register-root-reference (ref:ptr<long>, vms:ptr<core/VMState>) -> ref<False> :
+    val v = [ref]
+    val tagbits = v & 7L ; heap object?
+    if tagbits == 1L :
+      val p = (v - 1) as ptr<long> ; remove tag bits to retrieve object pointer
+      add(roots(vms.dom), p as long)
+    return false
 
-;; Look up offset into sorted list of object addresses using binary search
-lostanza defn addr-to-id (xs:ptr<LSLongVector>, x:long) -> long :
-  var res:long = -1L
-  labels :
-    begin: goto loop(0L, xs.length)
-    loop (start:long, end:long) :
-      if end > start :
-        val center = (start + end) >> 1
-        val xc = xs.items[center]
-        if x == xc : res = center
-        else if x < xc : goto loop(start, center)
-        else : goto loop(center + 1L, end)
-  return res
-
-;;; LowFlatObject -- create flat and packed version of roots and objects
-;;;               -- stores tag, num-refs, refs for each object
-;;;               -- also has extra root root object with ref per root
-
-lostanza deftype LowFlatObjects :
-  var sizes : ptr<LSLongVector> ; static sizes of objects
-  var offs  : ptr<LSLongVector> ; offsets to inlined objects in heap
-  var heap  : ptr<LSLongVector> ; | type | len | ids ... | ...
-
-lostanza deftype FlatObjects <: IndexedCollection&Lengthable :
-  value : ptr<LowFlatObjects>
-
-lostanza defn FlatObjects
-    (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
-  val lfo = call-c clib/stz_malloc(sizeof(LowFlatObjects)) as ptr<LowFlatObjects>
-  lfo.sizes = sizes
-  lfo.offs  = offs
-  lfo.heap  = heap
-  return new FlatObjects{ lfo }
-
-lostanza defmethod length (xs:ref<FlatObjects>) -> ref<Int> :
-  return new Int{xs.value.offs.length}
-
-lostanza defn offset (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
-  return new Int{xs.value.offs.items[id.value] as int}
-
-lostanza defmethod get (xs:ref<FlatObjects>, idx:ref<Int>) -> ref<Int> :
-  return new Int{xs.value.heap.items[idx.value] as int}
-
-; for some reason can't name this method get like in stanza runtime
-defn get-all (xs:FlatObjects, indices:Range) -> Seq<Int> :
-  seq({ xs[_] }, indices)
-
-defn tag-of (xs:FlatObjects, id:Int) -> Int :
-  xs[offset(xs, id)]
-
-lostanza defn size-of (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
-  return new Int{ xs.value.sizes.items[id.value] as int }
-
-defn sizes (objs:FlatObjects) -> Seq<Int> :
-  seq(size-of{objs, _}, 0 to length(objs))
-
-defn refs (objs:FlatObjects, id:Int) -> Seqable<Int> :
-  val off = offset(objs, id) ; base
-  val num-refs = objs[off + 1]
-  val refs-off = off + 2 
-  get-all(objs, refs-off to (refs-off + num-refs))
-
-;; Pack roots / heap into FlatObjects 
-lostanza defn FlatObjects () -> ref<FlatObjects> :
-  call-c clib/printf("GC...\n")
-  run-garbage-collector()
-  val vms:ptr<core/VMState> = call-prim flush-vm()
-  val dom = vms.dom
-  clear(offs(dom))
-  clear(sizes(dom))
-  clear(heap(dom))
-  ;; get all roots
-  register-all-roots(vms)
-  call-c clib/printf("FOUND %d ROOTS...\n", roots(dom).length)
-  ;; get sizes and addresses of objects on heap
-  add(sizes(dom), roots(dom).length as long) ; dummy root object
-  call-c clib/printf("COLLECT HEAP %lx OBJECT ADDRESSES AND SIZES...\n", vms.heap.start)
-  iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-address-and-size))
-  val nursery = core/nursery-start(addr(vms.heap))
-  call-c clib/printf("COLLECT NURSERY %lx OBJECT ADDRESSES AND SIZES...\n", nursery)
-  iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-address-and-size))
-  call-c clib/printf("FOUND %d OBJECTS...\n", addrs(dom).length)
-  ;; build heap data translated to object ids using addresses and binary search
-  add(offs(dom), 0L)  ; first root object
-  add(heap(dom), -1L) ; dummy root object tag
-  add(heap(dom), roots(dom).length as long)
-  call-c clib/printf("CONVERTING ROOT ADDRESSES TO IDS...\n")
-  for (var i:int = 0, i < roots(dom).length, i = i + 1) :
-    add(heap(dom), addr-to-id(addrs(dom), roots(dom).items[i]) + 1) ; point to roots
-  call-c clib/printf("PACKING HEAP DATA...\n")
-  iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-contents))
-  call-c clib/printf("PACKING NURSERY DATA...\n")
-  iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-contents))
-  clear(addrs(dom))
-  clear(roots(dom))
-  call-c clib/printf("DONE...\n")
-  return FlatObjects(sizes(dom), offs(dom), heap(dom))
-
-;;; FlatIdObjects
-
-;; Permutation wrapper of flat-objects
-defstruct FlatIdObjects :
-  order   : Tuple<Int>
-  reorder : Tuple<Int>
-  objs    : FlatObjects
-with:
-  printer => true
-
-defn sizes (o:FlatIdObjects) -> Seq<Int> :
-  gather(to-tuple(sizes(objs(o))), order(o))
-
-defn length (ios:FlatIdObjects) -> Int :
-  length(objs(ios))
-
-defn nexts (fobjs:FlatIdObjects) -> Tuple<List<Int>> :
-  val objs = objs(fobjs)
-  to-tuple $ for id in order(fobjs) seq :
-    to-list $ seq({ reorder(fobjs)[_] }, refs(objs, id))
-
-defn prevs (nexts:Tuple<List<Int>>) -> Tuple<List<Int>> :
-  val prevs = Array<List<Int>>(length(nexts), List())
-  for (next in nexts, id in 0 to false) do :
-    for r in next do :
-      prevs[r] = cons(id, prevs[r])
-  to-tuple $ prevs
-
-defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
-  FlatIdObjects(to-tuple $ (0 to length(objs)), to-tuple $ (0 to length(objs)), objs)
-
-;;; DOMINATORS
-
-;; find depth first order of objects
-defn depth-first (ios:FlatIdObjects) -> FlatIdObjects :
-  val nexts = nexts(ios)
-  val visited? = Array<True|False>(length(ios), false)
-  val order0 = Vector<Int>()
-  let loop (idx:Int = 0) :
-    if not visited?[idx] :
-      visited?[idx] = true
-      for nidx in nexts[idx] do : loop(nidx)
-      add(order0, idx)
-  val missing = filter({ not visited?[_] }, 0 to length(visited?))
-  val order = to-tuple $ cat(missing, order0)
-  FlatIdObjects(to-tuple $ order, scatter(0 to length(order), to-tuple(order)), objs(ios))
-
-; fast dominators algorithm assuming depth-first order
-defn idom (num:Int, prevs:Tuple<List<Int>>) -> Tuple<Int> :
-  val doms = Array<Int>(num, -1)
-  val start-id = num - 1
-  doms[start-id] = start-id
-  defn intersect (b1:Int, b2:Int) -> Int :
-    let loop (finger1:Int = b1, finger2:Int = b2) :
-      if finger1 != finger2 :
-        val finger1 = let iter (finger1:Int = finger1) :
-          if finger1 < finger2 : iter(doms[finger1])
-          else : finger1
-        val finger2 = let iter (finger2:Int = finger2) :
-          if finger2 < finger1 : iter(doms[finger2])
-          else : finger2
-        loop(finger1, finger2)
+  lostanza defn iterate-objects
+      (pstart:ptr<long>, pend:ptr<long>, vms:ptr<core/VMState>,
+       f:ptr<((ptr<long>, int, long, ptr<core/VMState>) -> ref<False>)>) -> ref<False> :
+    var p:ptr<long> = pstart
+    while p < pend :
+      val tag = [p] as int
+      val class = vms.class-table[tag].record
+      var size:long = 0L
+      if class.item-size == 0 :
+        size = object-size-on-heap(class.size)
       else :
-        finger1
-  let loop () :
-    let iter (b : Int = start-id - 1, changed? : True|False = false) :
-      if b >= 0 :
-        val new-idom = let find (idom:Int = -1, ps:List<Int> = prevs[b]) :
-          if empty?(ps) :
-            idom
-          else :
-            val p = head(ps)
-            val nxt-idom =
-              if doms[p] != -1 :
-                if idom == -1 : p
-                else : intersect(p, idom)
-              else : idom
-            find(nxt-idom, tail(ps))
-        val changed? = doms[b] != new-idom
-        doms[b] = new-idom
-        iter(b - 1, changed?)          
-      else :
-        loop() when changed?
-  to-tuple $ doms
+        val class = class as ptr<core/ArrayRecord>
+        val array = p as ptr<ObjectLayout>
+        val len = array.slots[0]
+        val base-size = class.base-size
+        val item-size = class.item-size
+        val my-size = base-size + item-size * len
+        size = object-size-on-heap(my-size)
+      [f](p, tag, size, vms)
+      p = p + size
+    return false 
 
-defn calc-sizes (ios:FlatIdObjects, doms:Tuple<Int>) -> Array<Int> :
-  val tot-sizes = to-array<Int> $ sizes(ios)
-  val len = length(ios)
-  for i in 0 to (len - 1) do :
-    if doms[i] >= 0 :
-      tot-sizes[doms[i]] = tot-sizes[doms[i]] + tot-sizes[i]
-  tot-sizes
+  ;; Look up offset into sorted list of object addresses using binary search
+  lostanza defn addr-to-id (xs:ptr<LSLongVector>, x:long) -> long :
+    var res:long = -1L
+    labels :
+      begin: goto loop(0L, xs.length)
+      loop (start:long, end:long) :
+        if end > start :
+          val center = (start + end) >> 1
+          val xc = xs.items[center]
+          if x == xc : res = center
+          else if x < xc : goto loop(start, center)
+          else : goto loop(center + 1L, end)
+    return res
 
-defn print-xml
-    (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>,
-     nexts:Tuple<List<Int>>, doms:Tuple<Int>, threshold:Int = 0) :
-  val objs = objs(id-objs)
-  defn children (doms:Tuple<Int>) -> Tuple<Tuple<Int>> :
-    val children = to-tuple $ repeatedly({ Vector<Int>() }, length(nexts))
-    for (dom in doms, id in 0 to false) do :
-      add(children[dom], id) when (dom >= 0 and dom != id)
-    map(to-tuple, children)
-  defn stringify (s:String) -> String :
-    replace(s, "&", "A")
-  defn P (n:Int, str:Printable) :
-    for i in 0 to (n * 2) do : print(s, " ")
-    println(s, str)
-  val kiddies = children(doms)
-  let walk (idx:Int = length(doms) - 1, depth:Int = 0) :
-    val id = order(id-objs)[idx]
-    val name = stringify(class-name(tag-of(objs, id)))
-    P(depth, "<%_ RETAINED=\"%_\" STATIC=\"%_\">" % [name, sizes[idx], size-of(objs, id)])
-    val childs = reverse $ to-list $ qsort({ sizes[_] }, filter({ sizes[_] > threshold }, kiddies[idx]))
-    for child in childs do :
-      walk(child, depth + 1)
-    P(depth, "</%_>" % [name])
+  ;;; LowFlatObject -- create flat and packed version of roots and objects
+  ;;;               -- stores tag, num-refs, refs for each object
+  ;;;               -- also has extra root root object with ref per root
 
-public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
-  val objs = FlatObjects()
-  val id-objs0 = objects-to-id-objects(objs)
-  val id-objs = depth-first(id-objs0)
-  val nxts = nexts(id-objs)
-  val doms = idom(length(id-objs), prevs(nxts))
-  val sizes = calc-sizes(id-objs, doms)
-  ; print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
-  val s = FileOutputStream(filename)
-  print-xml(s, id-objs, sizes, nxts, doms)
-  close(s)
-  id-objs
+  lostanza deftype LowFlatObjects :
+    var sizes : ptr<LSLongVector> ; static sizes of objects
+    var offs  : ptr<LSLongVector> ; offsets to inlined objects in heap
+    var heap  : ptr<LSLongVector> ; | type | len | ids ... | ...
 
-; heap-dominator-tree("sizes.xml")
+  lostanza deftype FlatObjects <: IndexedCollection&Lengthable :
+    value : ptr<LowFlatObjects>
 
-; defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
-;   print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])
-; 
-; defn print-id-object-guts (objs:FlatObjects) -> False :
-;   for id in 0 to length(objs) do :
-;     id-print-guts(id, tag-of(objs, id), refs(objs, id))
-;     println("")
-; 
-; defn id-print-stat (id:Int, tag:Int, tot-size:Int, size:Int) :
-;   print("%_ = {%_ %_ %_}" % [id, class-name(tag), size, tot-size])
-; 
-; defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
-;   val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
-;   for (id in ids, i in 0 to false) do :
-;     val tot-size = tot-sizes[id]
-;     if tot-size > 0 :
-;       id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
-;       println("")
+  lostanza defn FlatObjects
+      (sizes:ptr<LSLongVector>, offs:ptr<LSLongVector>, heap:ptr<LSLongVector>) -> ref<FlatObjects> :
+    val lfo = call-c clib/stz_malloc(sizeof(LowFlatObjects)) as ptr<LowFlatObjects>
+    lfo.sizes = sizes
+    lfo.offs  = offs
+    lfo.heap  = heap
+    return new FlatObjects{ lfo }
+
+  lostanza defmethod length (xs:ref<FlatObjects>) -> ref<Int> :
+    return new Int{xs.value.offs.length}
+
+  lostanza defn offset (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
+    return new Int{xs.value.offs.items[id.value] as int}
+
+  lostanza defmethod get (xs:ref<FlatObjects>, idx:ref<Int>) -> ref<Int> :
+    return new Int{xs.value.heap.items[idx.value] as int}
+
+  ; for some reason can't name this method get like in stanza runtime
+  defn get-all (xs:FlatObjects, indices:Range) -> Seq<Int> :
+    seq({ xs[_] }, indices)
+
+  defn tag-of (xs:FlatObjects, id:Int) -> Int :
+    xs[offset(xs, id)]
+
+  lostanza defn size-of (xs:ref<FlatObjects>, id:ref<Int>) -> ref<Int> :
+    return new Int{ xs.value.sizes.items[id.value] as int }
+
+  defn sizes (objs:FlatObjects) -> Seq<Int> :
+    seq(size-of{objs, _}, 0 to length(objs))
+
+  defn refs (objs:FlatObjects, id:Int) -> Seqable<Int> :
+    val off = offset(objs, id) ; base
+    val num-refs = objs[off + 1]
+    val refs-off = off + 2 
+    get-all(objs, refs-off to (refs-off + num-refs))
+
+  ;; Pack roots / heap into FlatObjects 
+  lostanza defn FlatObjects () -> ref<FlatObjects> :
+    call-c clib/printf("GC...\n")
+    run-garbage-collector()
+    val vms:ptr<core/VMState> = call-prim flush-vm()
+    val dom = vms.dom
+    clear(offs(dom))
+    clear(sizes(dom))
+    clear(heap(dom))
+    ;; get all roots
+    register-all-roots(vms)
+    call-c clib/printf("FOUND %d ROOTS...\n", roots(dom).length)
+    ;; get sizes and addresses of objects on heap
+    add(sizes(dom), roots(dom).length as long) ; dummy root object
+    call-c clib/printf("COLLECT HEAP %lx OBJECT ADDRESSES AND SIZES...\n", vms.heap.start)
+    iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-address-and-size))
+    val nursery = core/nursery-start(addr(vms.heap))
+    call-c clib/printf("COLLECT NURSERY %lx OBJECT ADDRESSES AND SIZES...\n", nursery)
+    iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-address-and-size))
+    call-c clib/printf("FOUND %d OBJECTS...\n", addrs(dom).length)
+    ;; build heap data translated to object ids using addresses and binary search
+    add(offs(dom), 0L)  ; first root object
+    add(heap(dom), -1L) ; dummy root object tag
+    add(heap(dom), roots(dom).length as long)
+    call-c clib/printf("CONVERTING ROOT ADDRESSES TO IDS...\n")
+    for (var i:int = 0, i < roots(dom).length, i = i + 1) :
+      add(heap(dom), addr-to-id(addrs(dom), roots(dom).items[i]) + 1) ; point to roots
+    call-c clib/printf("PACKING HEAP DATA...\n")
+    iterate-objects(vms.heap.start, vms.heap.old-objects-end, vms, addr(collect-object-contents))
+    call-c clib/printf("PACKING NURSERY DATA...\n")
+    iterate-objects(nursery, vms.heap.top, vms, addr(collect-object-contents))
+    clear(addrs(dom))
+    clear(roots(dom))
+    call-c clib/printf("DONE...\n")
+    return FlatObjects(sizes(dom), offs(dom), heap(dom))
+
+  ;;; FlatIdObjects
+
+  ;; Permutation wrapper of flat-objects
+  defstruct FlatIdObjects :
+    order   : Tuple<Int>
+    reorder : Tuple<Int>
+    objs    : FlatObjects
+  with:
+    printer => true
+
+  defn sizes (o:FlatIdObjects) -> Seq<Int> :
+    gather(to-tuple(sizes(objs(o))), order(o))
+
+  defn length (ios:FlatIdObjects) -> Int :
+    length(objs(ios))
+
+  defn nexts (fobjs:FlatIdObjects) -> Tuple<List<Int>> :
+    val objs = objs(fobjs)
+    to-tuple $ for id in order(fobjs) seq :
+      to-list $ seq({ reorder(fobjs)[_] }, refs(objs, id))
+
+  defn prevs (nexts:Tuple<List<Int>>) -> Tuple<List<Int>> :
+    val prevs = Array<List<Int>>(length(nexts), List())
+    for (next in nexts, id in 0 to false) do :
+      for r in next do :
+        prevs[r] = cons(id, prevs[r])
+    to-tuple $ prevs
+
+  defn objects-to-id-objects (objs:FlatObjects) -> FlatIdObjects :
+    FlatIdObjects(to-tuple $ (0 to length(objs)), to-tuple $ (0 to length(objs)), objs)
+
+  ;;; DOMINATORS
+
+  ;; find depth first order of objects
+  defn depth-first (ios:FlatIdObjects) -> FlatIdObjects :
+    val nexts = nexts(ios)
+    val visited? = Array<True|False>(length(ios), false)
+    val order0 = Vector<Int>()
+    let loop (idx:Int = 0) :
+      if not visited?[idx] :
+        visited?[idx] = true
+        for nidx in nexts[idx] do : loop(nidx)
+        add(order0, idx)
+    val missing = filter({ not visited?[_] }, 0 to length(visited?))
+    val order = to-tuple $ cat(missing, order0)
+    FlatIdObjects(to-tuple $ order, scatter(0 to length(order), to-tuple(order)), objs(ios))
+
+  ; fast dominators algorithm assuming depth-first order
+  defn idom (num:Int, prevs:Tuple<List<Int>>) -> Tuple<Int> :
+    val doms = Array<Int>(num, -1)
+    val start-id = num - 1
+    doms[start-id] = start-id
+    defn intersect (b1:Int, b2:Int) -> Int :
+      let loop (finger1:Int = b1, finger2:Int = b2) :
+        if finger1 != finger2 :
+          val finger1 = let iter (finger1:Int = finger1) :
+            if finger1 < finger2 : iter(doms[finger1])
+            else : finger1
+          val finger2 = let iter (finger2:Int = finger2) :
+            if finger2 < finger1 : iter(doms[finger2])
+            else : finger2
+          loop(finger1, finger2)
+        else :
+          finger1
+    let loop () :
+      let iter (b : Int = start-id - 1, changed? : True|False = false) :
+        if b >= 0 :
+          val new-idom = let find (idom:Int = -1, ps:List<Int> = prevs[b]) :
+            if empty?(ps) :
+              idom
+            else :
+              val p = head(ps)
+              val nxt-idom =
+                if doms[p] != -1 :
+                  if idom == -1 : p
+                  else : intersect(p, idom)
+                else : idom
+              find(nxt-idom, tail(ps))
+          val changed? = doms[b] != new-idom
+          doms[b] = new-idom
+          iter(b - 1, changed?)          
+        else :
+          loop() when changed?
+    to-tuple $ doms
+
+  defn calc-sizes (ios:FlatIdObjects, doms:Tuple<Int>) -> Array<Int> :
+    val tot-sizes = to-array<Int> $ sizes(ios)
+    val len = length(ios)
+    for i in 0 to (len - 1) do :
+      if doms[i] >= 0 :
+        tot-sizes[doms[i]] = tot-sizes[doms[i]] + tot-sizes[i]
+    tot-sizes
+
+  defn print-xml
+      (s:FileOutputStream, id-objs:FlatIdObjects, sizes:Array<Int>,
+       nexts:Tuple<List<Int>>, doms:Tuple<Int>, threshold:Int = 0) :
+    val objs = objs(id-objs)
+    defn children (doms:Tuple<Int>) -> Tuple<Tuple<Int>> :
+      val children = to-tuple $ repeatedly({ Vector<Int>() }, length(nexts))
+      for (dom in doms, id in 0 to false) do :
+        add(children[dom], id) when (dom >= 0 and dom != id)
+      map(to-tuple, children)
+    defn stringify (s:String) -> String :
+      replace(s, "&", "A")
+    defn P (n:Int, str:Printable) :
+      for i in 0 to (n * 2) do : print(s, " ")
+      println(s, str)
+    val kiddies = children(doms)
+    let walk (idx:Int = length(doms) - 1, depth:Int = 0) :
+      val id = order(id-objs)[idx]
+      val name = stringify(class-name(tag-of(objs, id)))
+      P(depth, "<%_ RETAINED=\"%_\" STATIC=\"%_\">" % [name, sizes[idx], size-of(objs, id)])
+      val childs = reverse $ to-list $ qsort({ sizes[_] }, filter({ sizes[_] > threshold }, kiddies[idx]))
+      for child in childs do :
+        walk(child, depth + 1)
+      P(depth, "</%_>" % [name])
+
+  public defn heap-dominator-tree (filename:String) :
+    val objs = FlatObjects()
+    val id-objs0 = objects-to-id-objects(objs)
+    val id-objs = depth-first(id-objs0)
+    val nxts = nexts(id-objs)
+    val doms = idom(length(id-objs), prevs(nxts))
+    val sizes = calc-sizes(id-objs, doms)
+    ; print-id-object-stats(objs, to-tuple $ gather(sizes, reorder(id-objs)))
+    val s = FileOutputStream(filename)
+    print-xml(s, id-objs, sizes, nxts, doms)
+    close(s)
+
+  ; heap-dominator-tree("sizes.xml")
+
+  ; defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
+  ;   print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])
+  ; 
+  ; defn print-id-object-guts (objs:FlatObjects) -> False :
+  ;   for id in 0 to length(objs) do :
+  ;     id-print-guts(id, tag-of(objs, id), refs(objs, id))
+  ;     println("")
+  ; 
+  ; defn id-print-stat (id:Int, tag:Int, tot-size:Int, size:Int) :
+  ;   print("%_ = {%_ %_ %_}" % [id, class-name(tag), size, tot-size])
+  ; 
+  ; defn print-id-object-stats (objs:FlatObjects, tot-sizes:Tuple<Int>) -> False :
+  ;   val ids = reverse $ to-list $ qsort({ tot-sizes[_] }, 0 to length(objs))
+  ;   for (id in ids, i in 0 to false) do :
+  ;     val tot-size = tot-sizes[id]
+  ;     if tot-size > 0 :
+  ;       id-print-stat(id, tag-of(objs, id), tot-size, size-of(objs, id))
+  ;       println("")
+
+#else :
+
+  public defn heap-dominator-tree (filename:String) : false
 

--- a/core/heap-analysis.stanza
+++ b/core/heap-analysis.stanza
@@ -342,7 +342,7 @@ public defn heap-dominator-tree (filename:String) -> FlatIdObjects :
   close(s)
   id-objs
 
-heap-dominator-tree("sizes.xml")
+; heap-dominator-tree("sizes.xml")
 
 ; defn id-print-guts (id:Int, tag:Int, refs:Seqable<Int>) :
 ;   print("%_ = {%_ %_}" % [id, class-name(tag), to-tuple $ refs])

--- a/core/long-vector.stanza
+++ b/core/long-vector.stanza
@@ -1,6 +1,5 @@
 defpackage core/long-vector :
   import core
-  import collections
 
 public lostanza deftype LSLongVector :
   var capacity: int

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -60,6 +60,7 @@ PKGFILES="math \
           core/debug-table \
           core/sighandler \
           core/local-table \
+          core/heap-analysis \
           arg-parser \
           line-wrap \
           stz/test-driver \


### PR DESCRIPTION
It shows the amount of memory that would be freed if all references to a particular object removed and it were garbage collected, called the retained size.  This would allow us to figure out what/why objects are being held onto and how to fix it.  The output is a dominator tree of memory usage starting from the memory roots and sorted at every level by retained memory size.  It is shown in XML so that you can collapse and expand introspection.  It shows the retained size and the static shallow size for each object.  The api is heap-dominator-tree (filename:String) which takes a filename for the xml file that is created and populated with the results.